### PR TITLE
UIDEXP-11: Add stripes field to the package.json as it required to ha…

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "react": "*",
     "react-router": "*",
     "react-router-dom": "*"
+  },
+  "stripes": {
+    "type": ""
   }
 }


### PR DESCRIPTION
## Purpose

Add _stripes_ field to the package.json as it required to have the module included in platform-complete in the scope of [UIDEXP-11](https://issues.folio.org/browse/UIDEXP-11).