### PR TITLE
UIDEXP-21: move getFileExtension from ui-data-import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 * Move accordion with jobs list to separated component. UIDEXP-6.
 * Add shared utils for initiating data export process. UIDEXP-20.
 * Move job logs component from ui-data-import. UIDEXP-16.
+* Move getFileExtension from ui-data-import. UIDEXP-21.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ export {
   createUrl,
   createOkapiHeaders,
   convertBytesToKilobytes,
+  getFileExtension,
 } from './lib/utils';
 export * from './lib/FileUploader';
 export { uploadFile } from './lib/FileUploader/utils';

--- a/lib/utils/getFileExtension.js
+++ b/lib/utils/getFileExtension.js
@@ -1,0 +1,11 @@
+/** @param {File | { name: string }} file */
+export const getFileExtension = file => {
+  if (file && file.name) {
+    const fileExtensionRegExp = /\.(\w+)$/;
+    const [extension = null] = (file.name.match(fileExtensionRegExp) || []);
+
+    return extension && extension.toLowerCase();
+  }
+
+  return null;
+};

--- a/lib/utils/getFileExtension.js
+++ b/lib/utils/getFileExtension.js
@@ -1,11 +1,11 @@
 /** @param {File | { name: string }} file */
 export const getFileExtension = file => {
-  if (file?.name) {
-    const fileExtensionRegExp = /\.(\w+)$/;
-    const [extension = null] = (file.name.match(fileExtensionRegExp) || []);
+  if (!file?.name) return null;
 
-    return extension?.toLowerCase();
-  }
+  const fileExtensionRegExp = /\.(\w+)$/;
+  const [extension] = file.name.match(fileExtensionRegExp) || [];
 
-  return null;
+  if (!extension) return null;
+
+  return extension.toLowerCase();
 };

--- a/lib/utils/getFileExtension.js
+++ b/lib/utils/getFileExtension.js
@@ -1,10 +1,10 @@
 /** @param {File | { name: string }} file */
 export const getFileExtension = file => {
-  if (file && file.name) {
+  if (file?.name) {
     const fileExtensionRegExp = /\.(\w+)$/;
     const [extension = null] = (file.name.match(fileExtensionRegExp) || []);
 
-    return extension && extension.toLowerCase();
+    return extension?.toLowerCase();
   }
 
   return null;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -4,5 +4,6 @@ export * from './convertDate';
 export * from './createUrl';
 export * from './createOkapiHeaders';
 export * from './convertBytesToKilobytes';
+export * from './getFileExtension';
 export * from './sort';
 export * from './constants';

--- a/lib/utils/tests/getFileExtension-test.js
+++ b/lib/utils/tests/getFileExtension-test.js
@@ -10,22 +10,22 @@ describe('getFileExtension', () => {
   it('should return file extension', () => {
     const testFile = new File([], 'test.csv');
 
-    expect(getFileExtension((testFile))).to.be.equal('.csv');
+    expect(getFileExtension((testFile))).to.equal('.csv');
   });
 
   it('should return null if extension does not match regExp', () => {
     const testFile = new File([], 'test');
 
-    expect(getFileExtension((testFile))).to.be.equal(null);
+    expect(getFileExtension((testFile))).to.equal(null);
   });
 
   it('should return null if no file name', () => {
     const testFile = new File([], '');
 
-    expect(getFileExtension(testFile)).to.be.equal(null);
+    expect(getFileExtension(testFile)).to.equal(null);
   });
 
   it('should return null if no file provided', () => {
-    expect(getFileExtension()).to.be.equal(null);
+    expect(getFileExtension()).to.equal(null);
   });
 });

--- a/lib/utils/tests/getFileExtension-test.js
+++ b/lib/utils/tests/getFileExtension-test.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import {
+  describe,
+  it,
+} from '@bigtest/mocha';
+
+import { getFileExtension } from '..';
+
+describe('getFileExtension', () => {
+  it('should return file extension', () => {
+    const testFile = new File([], 'test.csv');
+
+    expect(getFileExtension((testFile))).to.be.equal('.csv');
+  });
+
+  it('should return null if extension does not match regExp', () => {
+    const testFile = new File([], 'test');
+
+    expect(getFileExtension((testFile))).to.be.equal(null);
+  });
+
+  it('should return null if no file name', () => {
+    const testFile = new File([], '');
+
+    expect(getFileExtension(testFile)).to.be.equal(null);
+  });
+
+  it('should return null if no file provided', () => {
+    expect(getFileExtension()).to.be.equal(null);
+  });
+});


### PR DESCRIPTION
## Purpose:
Added getFileExtension function from ui-data-import to utils here because of reuse in scope of the [UIDEXP-21](https://issues.folio.org/browse/UIDEXP-21)