### PR TITLE
UIDEXP-37: Update stripes-smart-components to correct test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 * Implement DataFetcher component for making API requests upon interval. Refs UIDEXP-22.
 * Update JobLogs and related components according to changes in requirements . UIDEXP-7.
 * Rewrite DataFetcher with the class based approach instead of hooks as it was not consistent with the behavior in data-import. UIDEXP-23.
+* Updating `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-37.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@folio/stripes-cli": "^1.10.0",
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes-core": "^4.0.0",
-    "@folio/stripes-smart-components": "^2.12.0",
+    "@folio/stripes-smart-components": "^3.0.0",
     "@folio/stripes": "^3.0.0",
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",


### PR DESCRIPTION
## Purpose:
Updating `stripes-smart-components` to `v3.0.0` will help to avoid errors (for example current errors in tests)