### PR TITLE
UIDEXP-39: Add shared components for second settings pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.0 (IN PROGRESS)
 * Update `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-37.
 * Implement `SearchForm` component. Refs UIDEXP-51.
+* Add ProfilesLabel and SettingsLabel components for second settings pane. UIDEXP-39.
 
 ## [1.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-03-13)
 * Module is created. Add FileUploader component. Refs UIDEXP-11.

--- a/index.js
+++ b/index.js
@@ -23,3 +23,7 @@ export { uploadFile } from './lib/FileUploader/utils';
 export * from './lib/JobLogs';
 export * from './lib/DataFetcher';
 export * from './lib/SearchForm';
+export {
+  ProfilesLabel,
+  SettingsLabel,
+} from './lib/Settings';

--- a/lib/Settings/ProfilesLabel/ProfilesLabel.css
+++ b/lib/Settings/ProfilesLabel/ProfilesLabel.css
@@ -1,0 +1,13 @@
+@import "@folio/stripes-components/lib/variables.css";
+
+.profilesLabel {
+  display: flex;
+}
+.profilesLabel button {
+  margin-top: -3px;
+}
+
+.profilesPopoverContent {
+  font-size: var(--font-size-small);
+  text-align: left;
+}

--- a/lib/Settings/ProfilesLabel/ProfilesLabel.js
+++ b/lib/Settings/ProfilesLabel/ProfilesLabel.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { InfoPopover } from '@folio/stripes/components';
+
+import css from './ProfilesLabel.css';
+
+const ProfilesLabel = ({
+  link,
+  content,
+}) => {
+  return (
+    <div
+      data-test-profile-label
+      className={css.profilesLabel}
+    >
+      <FormattedMessage id="stripes-data-transfer-components.profiles" />
+      <InfoPopover
+        allowAnchorClick
+        hideOnButtonClick
+        buttonHref={link}
+        buttonLabel={<FormattedMessage id="stripes-data-transfer-components.learnMore" />}
+        content={content}
+        contentClass={css.profilesPopoverContent}
+        iconSize="medium"
+      />
+    </div>
+  );
+};
+
+ProfilesLabel.propTypes = {
+  link: PropTypes.string.isRequired,
+  content: PropTypes.node.isRequired,
+};
+
+export default ProfilesLabel;

--- a/lib/Settings/ProfilesLabel/index.js
+++ b/lib/Settings/ProfilesLabel/index.js
@@ -1,0 +1,1 @@
+export { default as ProfilesLabel } from './ProfilesLabel';

--- a/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
+++ b/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import {
+  describe,
+  beforeEach,
+  afterEach,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../../test/bigtest/helpers';
+import {
+  ProfilesLabelInteractor,
+  ProfilesPopoverInteractor,
+} from './interactors';
+import ProfilesLabel from '../ProfilesLabel';
+
+import translations from '../../../../translations/stripes-data-transfer-components/en';
+
+describe('ProfilesLabel', () => {
+  const profilesLabel = new ProfilesLabelInteractor();
+  const popover = new ProfilesPopoverInteractor();
+
+  describe('rendering ProfileLabel', () => {
+    const link = 'http://localhost/';
+    const content = <div data-profiles-label-content>Content</div>;
+
+    beforeEach(async () => {
+      const overlayContainer = document.createElement('div');
+
+      overlayContainer.id = 'OverlayContainer';
+      document.body.append(overlayContainer);
+
+      await mountWithContext(
+        <ProfilesLabel
+          link={link}
+          content={content}
+        />
+      );
+    });
+
+    afterEach(() => {
+      document.getElementById('OverlayContainer').remove();
+    });
+
+    it('should display profiles label', () => {
+      expect(profilesLabel.isPresent).to.be.true;
+    });
+
+    it('should display the correct label text', () => {
+      expect(profilesLabel.text).to.equal(translations.profiles);
+    });
+
+    it('should display info icon button', () => {
+      expect(profilesLabel.infoButton.isPresent).to.be.true;
+    });
+
+    describe('clicking on info icon button', () => {
+      beforeEach(async () => {
+        await profilesLabel.infoButton.click();
+        await new Promise(resolve => { setTimeout(() => resolve(), 1000); });
+      });
+
+      it('should display passed in content', () => {
+        expect(popover.content.isPresent).to.be.true;
+      });
+
+      it('should apply correct href property', () => {
+        expect(popover.linkHref).to.equal(link);
+      });
+
+      it('should display passed in content', () => {
+        expect(popover.linkText).to.equal(translations.learnMore);
+      });
+    });
+  });
+});

--- a/lib/Settings/ProfilesLabel/tests/interactors/ProfilesLabelInteractor.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/ProfilesLabelInteractor.js
@@ -1,0 +1,12 @@
+import {
+  interactor,
+  scoped,
+} from '@bigtest/interactor';
+
+@interactor class ProfilesLabelInteractor {
+  static defaultScope = '[data-test-profile-label]';
+
+  infoButton = scoped('button');
+}
+
+export default ProfilesLabelInteractor;

--- a/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
@@ -1,0 +1,14 @@
+import {
+  interactor,
+  Interactor,
+  text,
+  property,
+} from '@bigtest/interactor';
+
+@interactor class ProfilesPopoverInteractor {
+  content = new Interactor('[data-profiles-label-content]');
+  linkHref = property('[class*=popoverPop---] a', 'href');
+  linkText = text('[class*=popoverPop---] a');
+}
+
+export default ProfilesPopoverInteractor;

--- a/lib/Settings/ProfilesLabel/tests/interactors/index.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/index.js
@@ -1,0 +1,2 @@
+export { default as ProfilesLabelInteractor } from './ProfilesLabelInteractor';
+export { default as ProfilesPopoverInteractor } from './ProfilesPopoverInteractor';

--- a/lib/Settings/SettingsLabel/SettingsLabel.js
+++ b/lib/Settings/SettingsLabel/SettingsLabel.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import { AppIcon } from '@folio/stripes/core';
+
+const SettingsLabel = ({
+  messageId,
+  iconKey,
+  app,
+}) => {
+  return (
+    <div data-test-settings-label>
+      <AppIcon
+        size="small"
+        app={app}
+        iconKey={iconKey}
+      >
+        <FormattedMessage id={messageId} />
+      </AppIcon>
+    </div>
+  );
+};
+
+SettingsLabel.propTypes = {
+  messageId: PropTypes.string.isRequired,
+  iconKey: PropTypes.string.isRequired,
+  app: PropTypes.string.isRequired,
+};
+
+export default SettingsLabel;

--- a/lib/Settings/SettingsLabel/index.js
+++ b/lib/Settings/SettingsLabel/index.js
@@ -1,0 +1,1 @@
+export { default as SettingsLabel } from './SettingsLabel';

--- a/lib/Settings/SettingsLabel/tests/SettingsLabel-test.js
+++ b/lib/Settings/SettingsLabel/tests/SettingsLabel-test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { mountWithContext } from '../../../../test/bigtest/helpers';
+import SettingsLabelInteractor from './interactor';
+import SettingsLabel from '../SettingsLabel';
+
+describe('SettingsLabel', () => {
+  const settingsLabel = new SettingsLabelInteractor();
+
+  describe('rendering SettingsLabel', () => {
+    const messageId = 'test_message_id';
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SettingsLabel
+          messageId={messageId}
+          iconKey="mappingProfiles"
+        />
+      );
+    });
+
+    it('should display settings label', () => {
+      expect(settingsLabel.isPresent).to.be.true;
+    });
+
+    it('should display app icon', () => {
+      expect(settingsLabel.icon.isPresent).to.be.true;
+    });
+
+    it('should display correct label text', () => {
+      expect(settingsLabel.labelText).to.equal(messageId);
+    });
+  });
+});

--- a/lib/Settings/SettingsLabel/tests/interactor.js
+++ b/lib/Settings/SettingsLabel/tests/interactor.js
@@ -1,0 +1,14 @@
+import {
+  interactor,
+  Interactor,
+  text,
+} from '@bigtest/interactor';
+
+@interactor class SettingsLabelInteractor {
+  static defaultScope = '[data-test-settings-label]';
+
+  icon = new Interactor('[class*=appIcon--]');
+  labelText = text('[class*=label---] span');
+}
+
+export default SettingsLabelInteractor;

--- a/lib/Settings/index.js
+++ b/lib/Settings/index.js
@@ -1,0 +1,2 @@
+export * from './ProfilesLabel';
+export * from './SettingsLabel';

--- a/translations/stripes-data-transfer-components/en.json
+++ b/translations/stripes-data-transfer-components/en.json
@@ -1,5 +1,7 @@
 {
   "loading": "Loading",
+  "profiles": "Profiles",
+  "learnMore": "Learn more",
   "fileName": "File name",
   "jobExecutionHrId": "ID",
   "jobProfileName": "Job profile",


### PR DESCRIPTION
## Purposes

Add shared components SettingsLabel and ProfilesLabel in scope of adding the second settings pane. [Story](https://issues.folio.org/browse/UIDEXP-39).