### PR TITLE
UIDEXP-51: Export interactors

### DIFF
--- a/interactors.js
+++ b/interactors.js
@@ -1,0 +1,1 @@
+export * from './lib/SearchForm/tests/interactor';

--- a/lib/SearchForm/tests/SearchForm-test.js
+++ b/lib/SearchForm/tests/SearchForm-test.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 import stripeSmartComponentsTranslations from '@folio/stripes-smart-components/translations/stripes-smart-components/en';
 import { SearchForm } from '../SearchForm';
-import SearchFormInteractor from './interactor';
+import { SearchFormInteractor } from './interactor';
 import { mountWithContext } from '../../../test/bigtest/helpers';
 
 async function setupSearchForm({

--- a/lib/SearchForm/tests/interactor.js
+++ b/lib/SearchForm/tests/interactor.js
@@ -6,10 +6,11 @@ import {
 import TextFieldInteractor from '@folio/stripes-components/lib/TextField/tests/interactor';
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
 
-export default interactor(class SearchFormInteractor {
+@interactor
+export class SearchFormInteractor {
   static defaultScope = '[data-test-search-form]';
 
   searchField = new TextFieldInteractor('[data-test-search-form]');
   searchSubmitButton = new ButtonInteractor('[data-test-search-form-submit]');
   searchSubmitButtonDisabled = property('[data-test-search-form-submit]', 'disabled');
-});
+}


### PR DESCRIPTION
## Purpose

Export interactors so other modules would not need to specify in the import the path to the whole project structure (e.g. `import SearchFormInteractor from '@folio/stripes-data-transfer-components/lib/SearchForm/tests/interactor';`) to the needed interactor and thus depend on the structure.