### PR TITLE
UIDEXP-58: Remove totalRecords value from defaultJobLogsColumnWidths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-37.
 * Implement `SearchForm` component. Refs UIDEXP-51.
 * Add ProfilesLabel and SettingsLabel components for second settings pane. UIDEXP-39.
+* Remove totalRecords value from defaultJobLogsColumnWidths settings for the jobs logs list. Refs UIDEXP-58.
 
 ## [1.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-03-13)
 * Module is created. Add FileUploader component. Refs UIDEXP-11.

--- a/lib/JobLogs/defaultJobLogsProps.js
+++ b/lib/JobLogs/defaultJobLogsProps.js
@@ -24,10 +24,7 @@ export const defaultJobLogsVisibleColumns = [
   'runBy',
 ];
 
-export const defaultJobLogsColumnWidths = {
-  hrId: '60px',
-  totalRecords: '80px',
-};
+export const defaultJobLogsColumnWidths = { hrId: '60px' };
 
 export const defaultJobLogsSortColumns = {
   hrId: {


### PR DESCRIPTION
## Purpose

UIDEXP-58: Remove `totalRecords` value from `defaultJobLogsColumnWidths` settings for the jobs logs list in the scope of the [UIDEXP-58](https://issues.folio.org/browse/UIDEXP-58).