### PR TITLE
UIDEXP-58: Adjust sortNumbers function to work correctly with empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Update `stripes-smart-components` to `v3.0.0` to avoid errors. UIDEXP-37.
 * Implement `SearchForm` component. Refs UIDEXP-51.
 * Add ProfilesLabel and SettingsLabel components for second settings pane. UIDEXP-39.
-* Remove totalRecords value from defaultJobLogsColumnWidths settings for the jobs logs list. Refs UIDEXP-58.
+* Remove totalRecords value from defaultJobLogsColumnWidths settings for the jobs logs list. Adjust `sortNumbers` function to work correctly with empty values. Refs UIDEXP-58.
 
 ## [1.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-03-13)
 * Module is created. Add FileUploader component. Refs UIDEXP-11.

--- a/lib/utils/sort.js
+++ b/lib/utils/sort.js
@@ -39,6 +39,6 @@ export function sortDates(a, b) {
  * @param {number} b
  * @return {number}
  */
-export function sortNumbers(a, b) {
+export function sortNumbers(a = 0, b = 0) {
   return a - b;
 }

--- a/lib/utils/tests/sort-test.js
+++ b/lib/utils/tests/sort-test.js
@@ -22,5 +22,7 @@ describe('sort functions', () => {
 
   it('should compare nums correctly ', () => {
     expect(sortNumbers(100, 20)).to.equal(80);
+    expect(sortNumbers(undefined, 20)).to.equal(-20);
+    expect(sortNumbers(20, undefined)).to.equal(20);
   });
 });


### PR DESCRIPTION
## Purpose

Adjust `sortNumbers` function to work correctly with null values in the scope of the [UIDEXP-58](https://issues.folio.org/browse/UIDEXP-58).