### PR TITLE
STDTC-7: Handle "form elements must have labels" accessibility problem for file uploader form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for stripes-data-transfer-components
 
 ## 1.1.0 (IN PROGRESS)
-* Implement `SearchForm` component. Refs UIDEXP-51.
-* Add ProfilesLabel and SettingsLabel components for second settings pane. UIDEXP-39.
-* Add mapping profiles pane component to display static data. Refs UIDEXP-41.
+* Implement `SearchForm` component. UIDEXP-51.
+* Add `ProfilesLabel` and `SettingsLabel` components for second settings pane. UIDEXP-39.
+* Add mapping profiles pane component to display static data. UIDEXP-41.
+* Handle "form elements must have labels" accessibility problem for the file uploader form. STDTC-7.
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/lib/FileUploader/FileUploader.js
+++ b/lib/FileUploader/FileUploader.js
@@ -26,6 +26,7 @@ export const FileUploader = ({
   children,
   style,
   getDataTransferItems,
+  inputProps,
   onDrop,
   onDragEnter,
   onDragLeave,
@@ -48,6 +49,7 @@ export const FileUploader = ({
         disabledClassName={disabledClassName}
         multiple={multiple}
         maxSize={maxSize}
+        inputProps={inputProps}
         getDataTransferItems={getDataTransferItems}
         onDrop={onDrop}
         onDragEnter={onDragEnter}
@@ -65,14 +67,16 @@ export const FileUploader = ({
               data-test-secondary-area
               hidden={isDropZoneActive}
             >
-              <Button
-                data-test-upload-btn
-                marginBottom0
-                buttonStyle="primary"
-                onClick={open}
-              >
-                {uploadButtonText}
-              </Button>
+              <label htmlFor={inputProps.id}>
+                <Button
+                  data-test-upload-btn
+                  marginBottom0
+                  buttonStyle="primary"
+                  onClick={open}
+                >
+                  {uploadButtonText}
+                </Button>
+              </label>
             </div>
             <div hidden={isDropZoneActive}>
               {isFunction(children) ? children(open) : children}
@@ -109,6 +113,10 @@ FileUploader.propTypes = {
     PropTypes.node,
     PropTypes.func,
   ]),
+  inputProps: PropTypes.shape({ id: PropTypes.string.isRequired }),
 };
 
-FileUploader.defaultProps = { multiple: true };
+FileUploader.defaultProps = {
+  multiple: true,
+  inputProps: { id: 'file-uploader-field' },
+};


### PR DESCRIPTION
## Purpose

Handle "form elements must have labels" accessibility problem for file uploader form in the scope of [STDTC-7](https://issues.folio.org/secure/RapidBoard.jspa?rapidView=112).

## Screenshots

### Before
<img width="400" alt="Screen Shot 2020-04-10 at 11 16 09" src="https://user-images.githubusercontent.com/40821852/78975527-f486d800-7b1c-11ea-8c5d-3c890556e3d9.png">

### After
<img width="400" alt="Screen Shot 2020-04-10 at 11 15 07" src="https://user-images.githubusercontent.com/40821852/78975570-05374e00-7b1d-11ea-9145-77032a13c04e.png">
