### PR TITLE
UIDEXP-49: Update jobs list structure according to the accessibility requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `ProfilesLabel` and `SettingsLabel` components for second settings pane. UIDEXP-39.
 * Add mapping profiles pane component to display static data. UIDEXP-41.
 * Handle "form elements must have labels" accessibility problem for the file uploader form. STDTC-7.
+* Update jobs list structure according to the accessibility requirements. UIDEXP-49.
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/lib/Jobs/Job/Job.css
+++ b/lib/Jobs/Job/Job.css
@@ -9,18 +9,16 @@
 }
 
 .job {
-  padding: .5rem;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius);
   font-size: var(--font-size-small);
   line-height: var(--line-height);
 
   &:not(:first-child) {
-    margin-top: 10px;
+    margin-top: var(--gutter-static-two-thirds);
   }
 }
 
 .jobHeader {
   font-size: var(--font-size-medium);
-  font-weight: 600;
+  font-weight: var(--text-weight-medium);
 }

--- a/lib/Jobs/Job/Job.js
+++ b/lib/Jobs/Job/Job.js
@@ -6,12 +6,12 @@ const Job = props => {
   const { children } = props;
 
   return (
-    <div
+    <li
       data-test-job-item
       className={css.job}
     >
       {children}
-    </div>
+    </li>
   );
 };
 

--- a/lib/Jobs/JobsList/JobsList.css
+++ b/lib/Jobs/JobsList/JobsList.css
@@ -1,13 +1,14 @@
+@import "@folio/stripes-components/lib/variables.css";
+
 .list {
-  background-color: transparent!important;
+  background-color: transparent !important;
+
+  & li {
+    display: block;
+    padding: var(--gutter-static-one-third);
+  }
 }
 
 .listContainer {
-  margin-bottom: 5px;
-}
-
-.emptyMessage {
-  display: block;
-  width: 100%;
-  text-align: center;
+  margin-bottom: var(--gutter-static-one-third);
 }

--- a/lib/Jobs/JobsList/JobsList.js
+++ b/lib/Jobs/JobsList/JobsList.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { List } from '@folio/stripes/components';
+import {
+  List,
+  Layout,
+} from '@folio/stripes/components';
 
 import EndOfItem from '../../EndOfItem';
 import Preloader from '../../Preloader';
@@ -16,12 +19,12 @@ const JobsList = ({
   isEmptyMessage = '',
 }) => {
   const EmptyMessage = (
-    <span
+    <Layout
+      className="textCentered"
       data-test-empty-message
-      className={css.emptyMessage}
     >
       {isEmptyMessage}
-    </span>
+    </Layout>
   );
 
   const LoadedJobsList = (


### PR DESCRIPTION
## Purpose

Update jobs list structure according to the accessibility requirements in the scope of [UIDEXP-49](https://issues.folio.org/browse/UIDEXP-49).

## Approach

Make sure that immediate children of `<ul>` tags be `<li>` elements.