### PR TITLE
STDTC-8: Create reusable search results view component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add mapping profiles pane component to display static data. UIDEXP-41.
 * Handle "form elements must have labels" accessibility problem for the file uploader form. STDTC-7.
 * Update jobs list structure according to the accessibility requirements. UIDEXP-49.
+* Create reusable `SearchResults` view component. STDTC-8.
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/lib/Jobs/JobsList/JobsList.js
+++ b/lib/Jobs/JobsList/JobsList.js
@@ -20,7 +20,8 @@ const JobsList = ({
 }) => {
   const EmptyMessage = (
     <Layout
-      className="textCentered"
+      className="flex centerContent"
+      element="span"
       data-test-empty-message
     >
       {isEmptyMessage}

--- a/lib/SearchForm/tests/SearchForm-test.js
+++ b/lib/SearchForm/tests/SearchForm-test.js
@@ -44,7 +44,7 @@ async function setupSearchForm({
   );
 }
 
-describe('rendering SearchForm', () => {
+describe('SearchForm', () => {
   const searchForm = new SearchFormInteractor();
 
   describe('rendering search form with non empty search term', () => {

--- a/lib/SearchResults/SearchResults.js
+++ b/lib/SearchResults/SearchResults.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { MultiColumnList } from '@folio/stripes/components';
+
+import Preloader from '../Preloader';
+
+export function SearchResults({
+  source,
+  notLoadedMessage,
+  resultCountIncrement,
+  ...rest
+}) {
+  return (
+    <MultiColumnList
+      id="search-results-list"
+      totalCount={source.totalCount()}
+      contentData={source.records()}
+      isEmptyMessage={source.pending() ? <Preloader /> : notLoadedMessage}
+      loading={source.pending()}
+      autosize
+      virtualize
+      onNeedMoreData={() => source.fetchMore(resultCountIncrement)}
+      {...rest}
+    />
+  );
+}
+
+SearchResults.propTypes = {
+  source: PropTypes.shape({
+    records: PropTypes.func.isRequired,
+    pending: PropTypes.func.isRequired,
+    totalCount: PropTypes.func.isRequired,
+    fetchMore: PropTypes.func.isRequired,
+  }).isRequired,
+  resultCountIncrement: PropTypes.number.isRequired,
+  notLoadedMessage: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
+};
+
+SearchResults.defaultProps = { notLoadedMessage: '' };

--- a/lib/SearchResults/index.js
+++ b/lib/SearchResults/index.js
@@ -1,0 +1,1 @@
+export * from './SearchResults';

--- a/lib/SearchResults/tests/SearchResults-test.js
+++ b/lib/SearchResults/tests/SearchResults-test.js
@@ -1,0 +1,140 @@
+import React from 'react';
+import { StaticRouter } from 'react-router';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { noop } from 'lodash';
+import {
+  describe,
+  beforeEach,
+  it,
+} from '@bigtest/mocha';
+
+import { SearchResultsInteractor } from './interactor';
+import { mountWithContext } from '../../../test/bigtest/helpers';
+import { SearchResults } from '../SearchResults';
+
+async function setupSearchResults(customProps, containerHeight = 300) {
+  const defaultProps = {
+    contentData: generateListContent(),
+    columnMapping: {
+      name: 'name',
+      description: 'description',
+    },
+    visibleColumns: ['name', 'description'],
+    pageAmount: 5,
+    resultCountIncrement: 5,
+    pending: false,
+    fetchMore: noop,
+  };
+  const {
+    contentData,
+    totalCount = contentData.length,
+    columnMapping,
+    visibleColumns,
+    pageAmount,
+    resultCountIncrement,
+    pending,
+    fetchMore,
+  } = {
+    ...defaultProps,
+    ...customProps,
+  };
+
+  await mountWithContext(
+    <StaticRouter context={{}}>
+      <div
+        style={{
+          height: `${containerHeight}px`,
+          width: '600px',
+        }}
+      >
+        <SearchResults
+          source={{
+            records: () => contentData,
+            pending: () => pending,
+            totalCount: () => totalCount,
+            fetchMore,
+          }}
+          notLoadedMessage={<span data-test-not-loaded-message>Not loaded</span>}
+          columnMapping={columnMapping}
+          visibleColumns={visibleColumns}
+          pageAmount={pageAmount}
+          resultCountIncrement={resultCountIncrement}
+        />
+      </div>
+    </StaticRouter>
+  );
+}
+
+const generateListContent = (numOfRecords = 2) => {
+  return Array.from({ length: numOfRecords }, (_, i) => ({
+    id: `id${i}`,
+    name: `name${i}`,
+    description: `description${i}`,
+  }));
+};
+
+describe('SearchResults', () => {
+  const searchResults = new SearchResultsInteractor();
+
+  describe('rendering search results with content data empty and API request pending', () => {
+    beforeEach(async () => {
+      await setupSearchResults({
+        contentData: [],
+        pending: true,
+      });
+    });
+
+    it('should display preloader', () => {
+      expect(searchResults.preloader.isPresent).to.be.true;
+      expect(searchResults.notLoadedMessagePresent).to.be.false;
+    });
+  });
+
+  describe('rendering search results with content data empty and API request loaded', () => {
+    beforeEach(async () => {
+      await setupSearchResults({ contentData: [] });
+    });
+
+    it('should display empty message', () => {
+      expect(searchResults.preloader.isPresent).to.be.false;
+      expect(searchResults.notLoadedMessagePresent).to.be.true;
+    });
+  });
+
+  describe('rendering search results with content data and pending API request', () => {
+    beforeEach(async () => {
+      await setupSearchResults({ pending: true });
+    });
+
+    it('should display list loader indicator', () => {
+      expect(searchResults.list.displaysLoadingIcon).to.be.true;
+    });
+  });
+
+  describe('rending search results with content data', () => {
+    const fetchMore = sinon.spy();
+    const resultCountIncrement = 5;
+
+    beforeEach(async () => {
+      fetchMore.resetHistory();
+
+      await setupSearchResults({
+        contentData: generateListContent(5),
+        totalCount: 10,
+        resultCountIncrement,
+        fetchMore,
+      }, 100);
+    });
+
+    describe('scrolling the list to the bottom', () => {
+      beforeEach(async () => {
+        await searchResults.list.scrollBody(200);
+      });
+
+      it('should initiate fetching of the next chunk of data', () => {
+        expect(fetchMore.calledWith(resultCountIncrement)).to.be.true;
+      });
+    });
+  });
+});

--- a/lib/SearchResults/tests/interactor.js
+++ b/lib/SearchResults/tests/interactor.js
@@ -1,0 +1,19 @@
+import {
+  interactor,
+  isPresent,
+} from '@bigtest/interactor';
+
+import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
+
+import PreloaderInteractor from '../../Preloader/tests/interactor';
+
+@interactor
+export class SearchResultsInteractor {
+  list = new MultiColumnListInteractor('#search-results-list');
+  preloader = new PreloaderInteractor();
+  notLoadedMessagePresent = isPresent('[data-test-not-loaded-message]');
+
+  getCellContent(row, cell) {
+    return this.list.rows(row).cells(cell).content;
+  }
+}

--- a/lib/Settings/MappingProfiles/MappingProfiles.js
+++ b/lib/Settings/MappingProfiles/MappingProfiles.js
@@ -1,14 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Pane,
-  MultiColumnList,
-} from '@folio/stripes/components';
+import { withRouter } from 'react-router';
+import { noop } from 'lodash';
+
+import { Pane } from '@folio/stripes/components';
 
 import { SettingsLabel } from '../SettingsLabel';
 import { SearchForm } from '../../SearchForm';
+import { SearchResults } from '../../SearchResults';
 import getItemFormatter from './getItemFormatter';
 import { getMappingProfilesColumnProperties } from './columnProperties';
+
+const RESULT_COUNT_INCREMENT = 30;
 
 const MappingProfiles = props => {
   const {
@@ -27,7 +30,6 @@ const MappingProfiles = props => {
         <SettingsLabel
           messageId="stripes-data-transfer-components.mappingProfilesTitle"
           iconKey="mappingProfiles"
-          app="data-export"
         />
       )}
     >
@@ -35,15 +37,20 @@ const MappingProfiles = props => {
         searchTerm=" "
         searchLabelKey="stripes-data-transfer-components.search"
       />
-      <MultiColumnList
-        id="mapping-profiles-list"
-        totalCount={contentData.length}
-        contentData={contentData}
+      <SearchResults
+        source={{
+          records: () => contentData,
+          pending: () => false,
+          totalCount: () => contentData.length,
+          fetchMore: noop,
+        }}
         columnMapping={columnMapping}
         visibleColumns={visibleColumns}
         columnWidths={columnWidths}
         formatter={formatter}
-        autosize
+        resultCountIncrement={RESULT_COUNT_INCREMENT}
+        // TODO: uncomment line below when start working on details page (`match` and `location` should be destructured from props) (UIDEXP-50)
+        // rowProps={{ href: id => `${match.path}/view/${id}${location.search}` }}
       />
     </Pane>
   );
@@ -63,4 +70,4 @@ MappingProfiles.defaultProps = {
   formatter: getItemFormatter(),
 };
 
-export default MappingProfiles;
+export default withRouter(MappingProfiles);

--- a/lib/Settings/MappingProfiles/tests/MappingProfiles-test.js
+++ b/lib/Settings/MappingProfiles/tests/MappingProfiles-test.js
@@ -5,6 +5,7 @@ import {
   beforeEach,
   it,
 } from '@bigtest/mocha';
+import { StaticRouter } from 'react-router';
 
 import { mountWithContext } from '../../../../test/bigtest/helpers';
 import MappingProfiles from '../MappingProfiles';
@@ -23,7 +24,11 @@ describe('MappingProfiles', () => {
 
   describe('rendering MappingProfiles with empty profiles list', () => {
     beforeEach(async () => {
-      await mountWithContext(<MappingProfiles />);
+      await mountWithContext(
+        <StaticRouter context={{}}>
+          <MappingProfiles />
+        </StaticRouter>
+      );
     });
 
     it('should be visible', () => {
@@ -39,7 +44,7 @@ describe('MappingProfiles', () => {
     });
 
     it('should hide mapping profiles list', () => {
-      expect(mappingProfiles.profilesList.isPresent).to.be.false;
+      expect(mappingProfiles.searchResults.list.isPresent).to.be.false;
     });
   });
 
@@ -60,62 +65,64 @@ describe('MappingProfiles', () => {
       customProperties.columnWidths[customColumnName] = '100px';
 
       await mountWithContext(
-        <MappingProfiles
-          contentData={mappingProfilesData}
-          formatter={getItemFormatter({ format: record => record.description })}
-          {...getMappingProfilesColumnProperties({
-            visibleColumns,
-            customProperties,
-          })}
-        />
+        <StaticRouter context={{}}>
+          <MappingProfiles
+            contentData={mappingProfilesData}
+            formatter={getItemFormatter({ format: record => record.description })}
+            {...getMappingProfilesColumnProperties({
+              visibleColumns,
+              customProperties,
+            })}
+          />
+        </StaticRouter>
       );
     });
 
     it('should display mapping profiles list', () => {
-      expect(mappingProfiles.profilesList.isPresent).to.be.true;
+      expect(mappingProfiles.searchResults.list.isPresent).to.be.true;
     });
 
     it('should place headers in correct order', () => {
-      expect(mappingProfiles.profilesList.headers(0).text).to.equal(translations.name);
-      expect(mappingProfiles.profilesList.headers(1).text).to.equal(translations.folioRecordType);
-      expect(mappingProfiles.profilesList.headers(2).text).to.equal(translations.updated);
-      expect(mappingProfiles.profilesList.headers(3).text).to.equal(translations.updatedBy);
-      expect(mappingProfiles.profilesList.headers(4).text).to.equal(customColumnName);
+      expect(mappingProfiles.searchResults.list.headers(0).text).to.equal(translations.name);
+      expect(mappingProfiles.searchResults.list.headers(1).text).to.equal(translations.folioRecordType);
+      expect(mappingProfiles.searchResults.list.headers(2).text).to.equal(translations.updated);
+      expect(mappingProfiles.searchResults.list.headers(3).text).to.equal(translations.updatedBy);
+      expect(mappingProfiles.searchResults.list.headers(4).text).to.equal(customColumnName);
     });
 
     it('should display correct names', () => {
-      expect(mappingProfiles.getCellContent(0, 0)).to.equal('AP holdings-MARC Bib');
-      expect(mappingProfiles.getCellContent(1, 0)).to.equal('AP Instance');
-      expect(mappingProfiles.getCellContent(2, 0)).to.equal('AP item from MARC');
-      expect(mappingProfiles.getCellContent(3, 0)).to.equal('Brief MARC Bib from MARC');
+      expect(mappingProfiles.searchResults.getCellContent(0, 0)).to.equal('AP holdings-MARC Bib');
+      expect(mappingProfiles.searchResults.getCellContent(1, 0)).to.equal('AP Instance');
+      expect(mappingProfiles.searchResults.getCellContent(2, 0)).to.equal('AP item from MARC');
+      expect(mappingProfiles.searchResults.getCellContent(3, 0)).to.equal('Brief MARC Bib from MARC');
     });
 
     it('should display folio records types', () => {
-      expect(mappingProfiles.getCellContent(0, 1)).to.equal(translations['recordTypes.holdings']);
-      expect(mappingProfiles.getCellContent(1, 1)).to.equal(translations['recordTypes.instance']);
-      expect(mappingProfiles.getCellContent(2, 1)).to.equal(translations['recordTypes.item']);
-      expect(mappingProfiles.getCellContent(3, 1)).to.equal(translations['recordTypes.marc-bib']);
+      expect(mappingProfiles.searchResults.getCellContent(0, 1)).to.equal(translations['recordTypes.holdings']);
+      expect(mappingProfiles.searchResults.getCellContent(1, 1)).to.equal(translations['recordTypes.instance']);
+      expect(mappingProfiles.searchResults.getCellContent(2, 1)).to.equal(translations['recordTypes.item']);
+      expect(mappingProfiles.searchResults.getCellContent(3, 1)).to.equal(translations['recordTypes.marc-bib']);
     });
 
     it('should display update dates', () => {
-      expect(mappingProfiles.getCellContent(0, 2)).to.equal('12/4/2018');
-      expect(mappingProfiles.getCellContent(1, 2)).to.equal('11/4/2018');
-      expect(mappingProfiles.getCellContent(2, 2)).to.equal('12/7/2018');
-      expect(mappingProfiles.getCellContent(3, 2)).to.equal('12/7/2018');
+      expect(mappingProfiles.searchResults.getCellContent(0, 2)).to.equal('12/4/2018');
+      expect(mappingProfiles.searchResults.getCellContent(1, 2)).to.equal('11/4/2018');
+      expect(mappingProfiles.searchResults.getCellContent(2, 2)).to.equal('12/7/2018');
+      expect(mappingProfiles.searchResults.getCellContent(3, 2)).to.equal('12/7/2018');
     });
 
     it('should display correct updated by values', () => {
-      expect(mappingProfiles.getCellContent(0, 3)).to.equal('John M');
-      expect(mappingProfiles.getCellContent(1, 3)).to.equal('Mark D');
-      expect(mappingProfiles.getCellContent(2, 3)).to.equal('Block Madyson');
-      expect(mappingProfiles.getCellContent(3, 3)).to.equal('Denis Lewis');
+      expect(mappingProfiles.searchResults.getCellContent(0, 3)).to.equal('John M');
+      expect(mappingProfiles.searchResults.getCellContent(1, 3)).to.equal('Mark D');
+      expect(mappingProfiles.searchResults.getCellContent(2, 3)).to.equal('Block Madyson');
+      expect(mappingProfiles.searchResults.getCellContent(3, 3)).to.equal('Denis Lewis');
     });
 
     it('should display correct descriptions', () => {
-      expect(mappingProfiles.getCellContent(0, 4)).to.equal('Use for PurpleVendor approval plan MARC files');
-      expect(mappingProfiles.getCellContent(1, 4)).to.equal('Use for PurpleVendor approval plan MARC files');
-      expect(mappingProfiles.getCellContent(2, 4)).to.equal('Use for PurpleVendor approval plan MARC files');
-      expect(mappingProfiles.getCellContent(3, 4)).to.equal('Create new MARC bib - brief');
+      expect(mappingProfiles.searchResults.getCellContent(0, 4)).to.equal('Use for PurpleVendor approval plan MARC files');
+      expect(mappingProfiles.searchResults.getCellContent(1, 4)).to.equal('Use for PurpleVendor approval plan MARC files');
+      expect(mappingProfiles.searchResults.getCellContent(2, 4)).to.equal('Use for PurpleVendor approval plan MARC files');
+      expect(mappingProfiles.searchResults.getCellContent(3, 4)).to.equal('Create new MARC bib - brief');
     });
   });
 });

--- a/lib/Settings/MappingProfiles/tests/interactor.js
+++ b/lib/Settings/MappingProfiles/tests/interactor.js
@@ -3,18 +3,13 @@ import {
   scoped,
 } from '@bigtest/interactor';
 
-import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
-
 import { SearchFormInteractor } from '../../../SearchForm/tests/interactor';
+import { SearchResultsInteractor } from '../../../SearchResults/tests/interactor';
 
 @interactor export class MappingProfilesInteractor {
   static defaultScope = '[data-test-mapping-profiles-pane]';
 
   searchForm = new SearchFormInteractor();
   paneTitle = scoped('[data-test-settings-label]');
-  profilesList = scoped('#mapping-profiles-list', MultiColumnListInteractor);
-
-  getCellContent(row, cell) {
-    return this.profilesList.rows(row).cells(cell).content;
-  }
+  searchResults = new SearchResultsInteractor();
 }


### PR DESCRIPTION
## Purpose

Create a reusable `SearchResults` view component in the scope of [STDTC-8](https://issues.folio.org/browse/STDTC-8).