### PR TITLE
UIDEXP-96: Improve FullScreenForm iteractor

### DIFF
--- a/lib/FullScreenForm/tests/interactor.js
+++ b/lib/FullScreenForm/tests/interactor.js
@@ -10,7 +10,7 @@ import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interac
 export class FullScreenFormInteractor {
   defaultScope = '[data-test-full-screen-form]';
 
-  header = new Interactor('[data-test-pane-header]');
+  header = new Interactor('[data-test-full-screen-form] [data-test-pane-header]');
   content = new Interactor('[data-test-full-screen-form-content]');
   submitButton = scoped('[data-test-submit-button]', ButtonInteractor);
   cancelButton = scoped('[data-test-cancel-button]', ButtonInteractor);


### PR DESCRIPTION
## Purpose

Improve `FullScreenForm` iteractor by providing namespace for pane header in order to be able to use it in other repositories.