### PR TITLE
UIDEXP-46: Export test utils and extend FOLIO record types list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Move `FullScreenFormComponent` from ui-data-import project. UIDEXP-96.
 * Add icon for job profiles. UIDEXP-79.
 * Update to Stripes v4. STDTC-10.
+* Export test utils and extend FOLIO record types list. UIDEXP-46.
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ export {
   sortDates,
   sortStrings,
   sortNumbers,
+  FOLIO_RECORD_TYPES,
 } from './lib/utils';
 export * from './lib/FileUploader';
 export { uploadFile } from './lib/FileUploader/utils';
@@ -26,3 +27,8 @@ export * from './lib/SearchForm';
 export * from './lib/Settings';
 export * from './lib/SearchAndSortPane';
 export * from './lib/FullScreenForm';
+export {
+  mount,
+  mountWithContext,
+  wait,
+} from './test/bigtest/helpers';

--- a/lib/utils/folioRecordTypes.js
+++ b/lib/utils/folioRecordTypes.js
@@ -11,6 +11,10 @@ export const FOLIO_RECORD_TYPES = {
     type: 'ITEM',
     captionId: 'stripes-data-transfer-components.recordTypes.item',
   },
+  ITEMS: {
+    type: 'ITEMS',
+    captionId: 'stripes-data-transfer-components.recordTypes.items',
+  },
   ORDER: {
     type: 'ORDER',
     captionId: 'stripes-data-transfer-components.recordTypes.order',

--- a/translations/stripes-data-transfer-components/en.json
+++ b/translations/stripes-data-transfer-components/en.json
@@ -18,11 +18,13 @@
   "recordTypes.orderLine": "Order & order line",
   "recordTypes.invoice": "Invoice",
   "recordTypes.item": "Item",
+  "recordTypes.items": "Items",
   "recordTypes.instance": "Instance",
   "recordTypes.holdings": "Holdings",
   "recordTypes.marc-bib": "MARC Bibliographic",
   "recordTypes.marc-auth": "MARC Authority",
   "recordTypes.marc-hold": "MARC Holdings",
   "search": "Search",
+  "validation.enterValue": "Please enter a value",
   "new": "New"
 }


### PR DESCRIPTION
## Purposes

Extend FOLIO record types list and export shared test utils to prevent code duplication. [Story](https://issues.folio.org/browse/UIDEXP-46)