### PR TITLE
UIDEXP-82: Export PreloaderInteractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 * Update to Stripes v4. STDTC-10.
 * Export test utils and extend FOLIO record types list. UIDEXP-46.
 * Implement `JobProfiles` list component. UIDEXP-80.
-* Update formatter for `MatchProfiles` list items. UIDEXP-57.
+* Update formatter for `MappingProfiles` list items. UIDEXP-57.
+* Export PreloaderInteractor. UIDEXP-82.
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/interactors.js
+++ b/interactors.js
@@ -1,6 +1,7 @@
 export * from './lib/SearchForm/tests/interactor';
 export * from './lib/SearchAndSortPane/tests/SearchAndSortInteractor';
 export * from './lib/FullScreenForm/tests/interactor';
+export { default as PreloaderInteractor } from './lib/Preloader/tests/interactor';
 
 export {
   mount,


### PR DESCRIPTION
## Purposes

Export PreloaderInteractor for tests in ui-data-export. [Story](https://issues.folio.org/browse/UIDEXP-82)