### PR TITLE
UIDEXP-47: Clean up warnings in the console

### DIFF
--- a/lib/ListTemplate/listTemplate.js
+++ b/lib/ListTemplate/listTemplate.js
@@ -10,7 +10,7 @@ export const listTemplate = {
   },
   updatedBy: record => {
     if (!record.userInfo) {
-      return null;
+      return '';
     }
 
     const {

--- a/lib/ListTemplate/tests/listTemplate-test.js
+++ b/lib/ListTemplate/tests/listTemplate-test.js
@@ -39,7 +39,7 @@ describe('listTemplate', () => {
   });
 
   it('should format updatedBy field correctly', () => {
-    expect(listTemplate.updatedBy({})).to.equal(null);
+    expect(listTemplate.updatedBy({})).to.equal('');
   });
 
   it('should format completed date field value correctly', () => {

--- a/lib/Settings/MappingProfiles/listTemplate.js
+++ b/lib/Settings/MappingProfiles/listTemplate.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { FOLIO_RECORD_TYPES } from '../../utils';
@@ -9,10 +9,14 @@ export const listTemplate = {
   folioRecord: record => {
     const { recordTypes } = record;
 
-    return recordTypes.map((recordType, i) => {
-      const recordTypeValue = <FormattedMessage id={FOLIO_RECORD_TYPES[recordType].captionId} />;
+    return (
+      <span>
+        {recordTypes.map((recordType, i) => {
+          const recordTypeValue = <FormattedMessage id={FOLIO_RECORD_TYPES[recordType].captionId} />;
 
-      return !i ? recordTypeValue : <>, {recordTypeValue}</>;
-    });
+          return <Fragment key={recordType}>{i ? ', ' : ''}{recordTypeValue}</Fragment>;
+        })}
+      </span>
+    );
   },
 };

--- a/lib/Settings/MappingProfiles/tests/listTemplate-test.js
+++ b/lib/Settings/MappingProfiles/tests/listTemplate-test.js
@@ -27,7 +27,7 @@ describe('MappingProfiles > listTemplate', () => {
   it('should format folio record field correctly', () => {
     const messageElement = listTemplate.folioRecord(mappingProfile);
 
-    expect(messageElement[0].props.id.endsWith('recordTypes.holdings')).to.equal(true);
+    expect(messageElement.props.children[0].props.children[1].props.id.endsWith('recordTypes.holdings')).to.equal(true);
   });
 
   it('should format updatedBy field correctly', () => {


### PR DESCRIPTION
## Purpose

Clean up warnings in the console below:
* WARN: 'Formatter possibly needed for column 'folioRecord': value is object;
* WARN: 'Formatter possibly needed for column 'updatedBy';