### PR TITLE
UIDEXP-97: Update record column for failed status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Implement `JobProfiles` list component. UIDEXP-80.
 * Update formatter for `MappingProfiles` list items. UIDEXP-57.
 * Export PreloaderInteractor. UIDEXP-82.
+* Update record column in jobs logs list for failed status. UIDEXP-97
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/lib/JobLogs/listTemplate.js
+++ b/lib/JobLogs/listTemplate.js
@@ -30,9 +30,14 @@ export const listTemplate = {
     return name;
   },
   totalRecords: record => {
-    const { progress: { total } } = record;
+    const {
+      progress: {
+        exported,
+        total,
+      },
+    } = record;
 
-    return total;
+    return exported ? total : '';
   },
   fileName: record => record.fileName,
   hrId: record => record.hrId,

--- a/lib/JobLogs/tests/listTemplate-test.js
+++ b/lib/JobLogs/tests/listTemplate-test.js
@@ -45,10 +45,21 @@ describe('JobLogs > listTemplate', () => {
     expect(listTemplate.jobProfileName(jobExecution)).to.equal(name);
   });
 
-  it('should format total records field value correctly', () => {
+  it('should format total records field value correctly if records are exported', () => {
     const { progress: { total } } = jobExecution;
 
     expect(listTemplate.totalRecords(jobExecution)).to.equal(total);
+  });
+
+  it('should format total records field value correctly if no records are exported', () => {
+    const failedJobExecution = {
+      progress: {
+        exported: 0,
+        total: 1,
+      },
+    };
+
+    expect(listTemplate.totalRecords(failedJobExecution)).to.equal('');
   });
 
   it('should format file name field value correctly', () => {

--- a/lib/tests/jobExecution.js
+++ b/lib/tests/jobExecution.js
@@ -14,7 +14,8 @@ const jobExecution = {
     lastName: 'Doe',
   },
   progress: {
-    current: 20000,
+    exported: 20000,
+    failed: 0,
     total: 20000,
   },
   startedDate: '2018-11-20T23:26:44.000+0000',

--- a/lib/tests/jobsLogs.js
+++ b/lib/tests/jobsLogs.js
@@ -9,7 +9,8 @@ const jobsLogsData = [
     sourcePath: 'path',
     fileName: 'import_28.mrc',
     progress: {
-      jobExecutionId: '3d790a2a-86de-46f9-a9ae-c9109bba746b',
+      exported: 7,
+      failed: 2,
       total: 9,
     },
     runBy: {
@@ -31,7 +32,8 @@ const jobsLogsData = [
     sourcePath: 'path',
     fileName: 'import_22.mrc',
     progress: {
-      jobExecutionId: '2e149aef-bb77-45aa-8a28-e139674b55e1',
+      exported: 7,
+      failed: 0,
       total: 7,
     },
     runBy: {
@@ -53,7 +55,8 @@ const jobsLogsData = [
     sourcePath: 'path',
     fileName: 'import_22.mrc',
     progress: {
-      jobExecutionId: '2e149aef-bb77-45aa-8a28-e139674b55e1',
+      exported: 46,
+      failed: 0,
       total: 46,
     },
     runBy: {
@@ -75,7 +78,8 @@ const jobsLogsData = [
     sourcePath: 'path',
     fileName: 'import_21.mrc',
     progress: {
-      jobExecutionId: '2e149aef-bb77-45aa-8a28-e139674b55e1',
+      exported: 10,
+      failed: 0,
       total: 10,
     },
     runBy: {


### PR DESCRIPTION
## Description
When none of records were exported successfully, value in `Records` should be empty according to the requirements.

## Issue

[UIDEXP-97](https://issues.folio.org/browse/UIDEXP-97)

## Screenshot
![image](https://user-images.githubusercontent.com/55701515/83634762-bf8e8300-a5ab-11ea-9c9e-6900c3d91a67.png)
