### PR TITLE
UIDEXP-38: Export ProgressInteractor and update job execution prop types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Update formatter for `MappingProfiles` list items. UIDEXP-57.
 * Export PreloaderInteractor. UIDEXP-82.
 * Update record column in jobs logs list for failed status. UIDEXP-97
+* Export ProgressInteractor and update job execution prop types. UIDEXP-38
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/interactors.js
+++ b/interactors.js
@@ -2,6 +2,7 @@ export * from './lib/SearchForm/tests/interactor';
 export * from './lib/SearchAndSortPane/tests/SearchAndSortInteractor';
 export * from './lib/FullScreenForm/tests/interactor';
 export { default as PreloaderInteractor } from './lib/Preloader/tests/interactor';
+export { default as ProgressInteractor } from './lib/Progress/tests/interactor';
 
 export {
   mount,

--- a/lib/Jobs/jobExecutionPropTypes.js
+++ b/lib/Jobs/jobExecutionPropTypes.js
@@ -16,11 +16,7 @@ const jobExecutionPropTypes = PropTypes.shape({
     firstName: PropTypes.string.isRequired,
     lastName: PropTypes.string.isRequired,
   }).isRequired,
-  progress: PropTypes.shape({
-    jobExecutionId: PropTypes.string,
-    current: PropTypes.number,
-    total: PropTypes.number.isRequired,
-  }).isRequired,
+  progress: PropTypes.object.isRequired,
   startedDate: PropTypes.string,
   completedDate: PropTypes.string,
   status: PropTypes.string.isRequired,


### PR DESCRIPTION
## Purposes

Export ProgressInteractor and update job execution proptypes according to changes on backend side. [Story](https://issues.folio.org/browse/UIDEXP-38)