### PR TITLE
UIDEXP-87: Extend `SearchAndSortPane` and `JobProfiles` with new props in order to adjust it for choose job profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
 * Implement `JobProfiles` list component. UIDEXP-80.
 * Update formatter for `MappingProfiles` list items. UIDEXP-57.
 * Export PreloaderInteractor. UIDEXP-82.
-* Update record column in jobs logs list for failed status. UIDEXP-97
-* Export ProgressInteractor and update job execution prop types. UIDEXP-38
+* Update record column in jobs logs list for failed status. UIDEXP-97.
+* Export ProgressInteractor and update job execution prop types. UIDEXP-38.
+* Extend `SearchAndSortPane` and `JobProfiles` with new props in order to adjust it for choose job profile page. UIDEXP-87.
 
 ## [1.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0) (2020-04-02)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.0...v1.0.1)

--- a/lib/Jobs/jobExecutionPropTypes.js
+++ b/lib/Jobs/jobExecutionPropTypes.js
@@ -2,12 +2,12 @@ import PropTypes from 'prop-types';
 
 const jobExecutionPropTypes = PropTypes.shape({
   id: PropTypes.string.isRequired,
-  hrId: PropTypes.number.isRequired,
+  hrId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   jobProfileInfo: PropTypes.shape({
     id: PropTypes.string,
     name: PropTypes.string,
     dataType: PropTypes.string,
-  }).isRequired,
+  }),
   parentJobId: PropTypes.string,
   subordinationType: PropTypes.string,
   sourcePath: PropTypes.string,

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -75,13 +75,18 @@ export class SearchAndSortPane extends Component {
     resourceName: PropTypes.string.isRequired,
     resultCountIncrement: PropTypes.number.isRequired,
     initialResultCount: PropTypes.number.isRequired,
+    hasSearchForm: PropTypes.bool,
+    lastMenu: PropTypes.element,
+    searchResultsProps: PropTypes.object,
   };
 
   static defaultProps = {
     maxSortKeys: 2,
     renderHeader: null,
     defaultSort: '',
+    hasSearchForm: true,
     searchLabelKey: 'stripes-data-transfer-components.search',
+    searchResultsProps: {},
   };
 
   constructor(props) {
@@ -218,6 +223,7 @@ export class SearchAndSortPane extends Component {
       match,
       location,
       resultCountIncrement,
+      searchResultsProps,
     } = this.props;
 
     const sortOrderQuery = this.queryParam('sort') || defaultSort;
@@ -236,6 +242,7 @@ export class SearchAndSortPane extends Component {
         sortOrder={sortOrder}
         sortDirection={sortDirection}
         rowProps={{ href: id => `${match.path}/view/${id}${location.search}` }}
+        {...searchResultsProps}
       />
     );
   };
@@ -247,6 +254,7 @@ export class SearchAndSortPane extends Component {
       renderHeader,
       match,
       location,
+      lastMenu,
     } = this.props;
 
     if (renderHeader) return renderHeader(this.props, renderProps);
@@ -261,7 +269,7 @@ export class SearchAndSortPane extends Component {
             values={{ count: this.getSource().totalCount() }}
           />
         )}
-        lastMenu={(
+        lastMenu={lastMenu || (
           <Button
             buttonStyle="primary paneHeaderNewButton"
             data-test-new-button
@@ -308,7 +316,7 @@ export class SearchAndSortPane extends Component {
           renderHeader={this.renderHeader}
         >
           <div className={css.paneBody}>
-            {this.renderSearchForm(source)}
+            {this.props.hasSearchForm && this.renderSearchForm(source)}
             <div className={css.searchResults}>
               {this.renderSearchResults(source)}
             </div>

--- a/lib/SearchAndSortPane/tests/SearchAndSortPane-test.js
+++ b/lib/SearchAndSortPane/tests/SearchAndSortPane-test.js
@@ -239,4 +239,58 @@ describe('SearchAndSortPane', () => {
       });
     });
   });
+
+  describe('rendering component without search form and header last menu and with custom search results props', () => {
+    const onRowClickSpy = sinon.spy();
+
+    beforeEach(async () => {
+      onRowClickSpy.resetHistory();
+      await mountWithContext(
+        <Router>
+          <SearchAndSortPane
+            label={(
+              <SettingsLabel
+                messageId={titleMessageId}
+                iconKey="customIcon"
+              />
+            )}
+            parentResources={parentResources}
+            parentMutator={parentMutator}
+            resultCountMessageId={resultCountMessage}
+            resultsFormatter={formatter}
+            defaultSort="name"
+            columnWidths={columnWidths}
+            visibleColumns={visibleColumns}
+            columnMapping={columnMapping}
+            stripes={{ logger: { log: noop } }}
+            resourceName="profiles"
+            hasSearchForm={false}
+            lastMenu={<span data-test-custom-last-menu />}
+            searchResultsProps={{
+              rowProps: null,
+              onRowClick: onRowClickSpy,
+            }}
+          />
+        </Router>
+      );
+    });
+
+    it('should display custom last menu', () => {
+      expect(pane.header.$('[data-test-custom-last-menu]')).to.not.be.undefined;
+    });
+
+    it('should not display search form', () => {
+      expect(pane.searchForm.isPresent).to.be.false;
+    });
+
+    describe('clicking on row', () => {
+      beforeEach(async () => {
+        await pane.searchResults.list.rows(0).click();
+      });
+
+      it('should call the subscribed callback provided via props for search results', () => {
+        expect(onRowClickSpy.called).to.be.true;
+      });
+    });
+  });
 });

--- a/lib/Settings/JobProfiles/JobProfiles.js
+++ b/lib/Settings/JobProfiles/JobProfiles.js
@@ -7,7 +7,10 @@ import { getJobProfilesColumnProperties } from './columnProperties';
 import { SearchAndSortPane } from '../../SearchAndSortPane';
 
 const JobProfiles = props => {
-  const { formatter } = props;
+  const {
+    formatter,
+    titleId,
+  } = props;
 
   return (
     <SearchAndSortPane
@@ -15,7 +18,7 @@ const JobProfiles = props => {
       objectName="job-profiles"
       label={(
         <SettingsLabel
-          messageId="stripes-data-transfer-components.jobProfilesTitle"
+          messageId={titleId}
           iconKey="jobProfiles"
         />
       )}
@@ -31,12 +34,14 @@ JobProfiles.propTypes = {
   formatter: PropTypes.object,
   resultCountIncrement: PropTypes.number,
   initialResultCount: PropTypes.number,
+  titleId: PropTypes.string,
   resourceName: PropTypes.string.isRequired,
 };
 
 JobProfiles.defaultProps = {
   ...getJobProfilesColumnProperties({}),
   formatter: getItemFormatter(),
+  titleId: 'stripes-data-transfer-components.jobProfilesTitle',
   resultCountIncrement: 30,
   initialResultCount: 30,
   resourceName: 'jobProfiles',

--- a/lib/Settings/JobProfiles/tests/JobProfiles-test.js
+++ b/lib/Settings/JobProfiles/tests/JobProfiles-test.js
@@ -52,11 +52,11 @@ describe('JobProfiles', () => {
       expect(jobProfiles.header.isPresent).to.be.true;
     });
 
-    it('should display field correct title', () => {
+    it('should display correct title', () => {
       expect(jobProfiles.header.title.labelText).to.equal(translations.jobProfilesTitle);
     });
 
-    it('should display field correct subtitle', () => {
+    it('should display correct subtitle', () => {
       expect(jobProfiles.header.subTitleText).to.equal('0 job profiles');
     });
 
@@ -71,6 +71,7 @@ describe('JobProfiles', () => {
 
   describe('rendering JobProfiles with filled profiles list and custom field', () => {
     const customColumnName = 'description';
+    const customTitleIdKey = 'name';
     const customProperties = getJobProfilesColumnProperties({
       columnMapping: { [customColumnName]: customColumnName },
       columnWidths: { [customColumnName]: '100px' },
@@ -93,6 +94,7 @@ describe('JobProfiles', () => {
             formatter={getItemFormatter({ format: record => record.description })}
             parentMutator={parentMutator}
             parentResources={parentResources}
+            titleId={`stripes-data-transfer-components.${customTitleIdKey}`}
             {...customProperties}
           />
         </Router>
@@ -101,6 +103,10 @@ describe('JobProfiles', () => {
 
     it('should display job profiles list', () => {
       expect(jobProfiles.searchResults.list.isPresent).to.be.true;
+    });
+
+    it('should display custom title', () => {
+      expect(jobProfiles.header.title.labelText).to.equal(translations[customTitleIdKey]);
     });
 
     it('should place headers in correct order', () => {


### PR DESCRIPTION
## Purpose

Extend `SearchAndSortPane`  and `JobProfiles` with new props in order to adjust it for choose job profile page in the scope of [UIDEXP-87](https://issues.folio.org/browse/UIDEXP-87).

List of new props:

`SearchAndSortPane`:
 - `hasSearchForm` - for making it possible to hide search form (`true` by default);
 - `lastMenu` - for making it possible to provide custom header last menu (nothing by default);
 - `searchResultsProps` - for making it possible to provide custom search results props which would make it possible to override some existing props and provide new ones (`{}` by default);

`JobProfiles`:
 - `titleId` - for making it possible to provide custom title id (`stripes-data-transfer-components.jobProfilesTitle` by default);
