### PR TITLE
UIDEXP-107: Fix error screen display in case of missed user information in job executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-data-transfer-components
 
 ## 2.1.0 (IN PROGRESS)
+* Fix error screen display in case of missed user information in job executions. UIDEXP-107.
 
 ## [2.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.1...v2.0.0)

--- a/lib/JobLogs/listTemplate.js
+++ b/lib/JobLogs/listTemplate.js
@@ -3,6 +3,10 @@ import { FormattedTime } from 'react-intl';
 
 export const listTemplate = {
   runBy: record => {
+    if (!record.runBy) {
+      return '';
+    }
+
     const {
       runBy: {
         firstName,

--- a/lib/JobLogs/tests/listTemplate-test.js
+++ b/lib/JobLogs/tests/listTemplate-test.js
@@ -19,6 +19,7 @@ describe('JobLogs > listTemplate', () => {
     } = jobExecution;
 
     expect(listTemplate.runBy(jobExecution)).to.equal(`${firstName} ${lastName}`);
+    expect(listTemplate.runBy({})).to.equal('');
   });
 
   it('should format completed date field value correctly', () => {


### PR DESCRIPTION
## Purposes

The user info can't be provided in some cases according to the latests information. So the check is added to prevent the main page crashing. [Issue](https://issues.folio.org/browse/UIDEXP-107).