### PR TITLE
UIDEXP-53: Update properties in ProfilesPopoverInteractor and export ProfilesLabelInteractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0 (IN PROGRESS)
 * Fix error screen display in case of missed user information in job executions. UIDEXP-107.
+* Update properties in ProfilesPopoverInteractor and export ProfilesLabelInteractors. UIDEXP-53.
 
 ## [2.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.1...v2.0.0)

--- a/interactors.js
+++ b/interactors.js
@@ -2,6 +2,7 @@ export * from './lib/SearchForm/tests/interactor';
 export * from './lib/SearchAndSortPane/tests/SearchAndSortInteractor';
 export * from './lib/FullScreenForm/tests/interactor';
 export * from './lib/FullScreenView/tests/interactor';
+export * from './lib/Settings/ProfilesLabel/tests/interactors';
 export { default as PreloaderInteractor } from './lib/Preloader/tests/interactor';
 export { default as ProgressInteractor } from './lib/Progress/tests/interactor';
 

--- a/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
@@ -5,8 +5,12 @@ import {
   property,
 } from '@bigtest/interactor';
 
+import css from '../../ProfilesLabel.css';
+
 @interactor class ProfilesPopoverInteractor {
-  content = new Interactor('[data-profiles-label-content]');
+  static defaultScope = '[data-role="popover"]';
+
+  content = new Interactor(`.${css.profilesPopoverContent}`);
   linkHref = property('[class*=popoverPop---] a', 'href');
   linkText = text('[class*=popoverPop---] a');
 }


### PR DESCRIPTION
## Purposes

Update properties (link to content and scope) in ProfilesPovoerInteractor and export ProfilesPovoerInteractor. [Story](https://issues.folio.org/browse/UIDEXP-53)