### PR TITLE
Move react-intl from ^4.5 to ~4.6 to avoid broken changes in 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (IN PROGRESS)
 * Fix error screen display in case of missed user information in job executions. UIDEXP-107.
 * Update properties in ProfilesPopoverInteractor and export ProfilesLabelInteractors. UIDEXP-53.
+* Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744.  
 
 ## [2.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.1...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-router-dom": "^5.0.1",
-    "react-intl": "^4.5.1",
+    "react-intl": "~4.6.10",
     "regenerator-runtime": "^0.13.3",
     "core-js": "^3.6.1",
     "sinon": "^7.1.1"
@@ -53,7 +53,7 @@
     "@folio/stripes": "^4.0.0",
     "pretender": "*",
     "react": "*",
-    "react-intl": "^4.5.1",
+    "react-intl": "~4.6.10",
     "react-router": "*",
     "react-router-dom": "*"
   },


### PR DESCRIPTION
## Purposes

Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744. 