### PR TITLE
UIDEXP-116: Add job name display in job logs and executions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.1.0 (IN PROGRESS)
 * Fix error screen display in case of missed user information in job executions. UIDEXP-107.
 * Update properties in ProfilesPopoverInteractor and export ProfilesLabelInteractors. UIDEXP-53.
-* Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744.  
+* Add job name display in job logs and executions. UIDEXP-116.
 
 ## [2.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.1...v2.0.0)

--- a/lib/JobLogs/listTemplate.js
+++ b/lib/JobLogs/listTemplate.js
@@ -29,9 +29,9 @@ export const listTemplate = {
     );
   },
   jobProfileName: record => {
-    const { jobProfileInfo: { name } } = record;
+    const { jobProfileName } = record;
 
-    return name;
+    return jobProfileName;
   },
   totalRecords: record => {
     const {

--- a/lib/JobLogs/tests/jobLogs-test.js
+++ b/lib/JobLogs/tests/jobLogs-test.js
@@ -228,7 +228,7 @@ describe('Job logs list', () => {
       });
     });
 
-    describe('clicking on jobProfileInfo field', () => {
+    describe('clicking on job profile name field', () => {
       beforeEach(async () => {
         await logsList.headers(2).click();
       });

--- a/lib/JobLogs/tests/listTemplate-test.js
+++ b/lib/JobLogs/tests/listTemplate-test.js
@@ -41,9 +41,9 @@ describe('JobLogs > listTemplate', () => {
   });
 
   it('should format job profile name field value correctly', () => {
-    const { jobProfileInfo: { name } } = jobExecution;
+    const { jobProfileName } = jobExecution;
 
-    expect(listTemplate.jobProfileName(jobExecution)).to.equal(name);
+    expect(listTemplate.jobProfileName(jobExecution)).to.equal(jobProfileName);
   });
 
   it('should format total records field value correctly if records are exported', () => {

--- a/lib/Jobs/jobExecutionPropTypes.js
+++ b/lib/Jobs/jobExecutionPropTypes.js
@@ -3,11 +3,7 @@ import PropTypes from 'prop-types';
 const jobExecutionPropTypes = PropTypes.shape({
   id: PropTypes.string.isRequired,
   hrId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  jobProfileInfo: PropTypes.shape({
-    id: PropTypes.string,
-    name: PropTypes.string,
-    dataType: PropTypes.string,
-  }),
+  jobProfileName: PropTypes.string,
   parentJobId: PropTypes.string,
   subordinationType: PropTypes.string,
   sourcePath: PropTypes.string,

--- a/lib/tests/jobExecution.js
+++ b/lib/tests/jobExecution.js
@@ -2,11 +2,8 @@ const jobExecution = {
   id: 'e451348f-2273-4b45-b385-0a8b0184b4e1',
   hrId: 112984432,
   subordinationType: 'PARENT_SINGLE',
-  jobProfileInfo: {
-    id: '448ae575-daec-49c1-8041-d64c8ed8e5b1',
-    name: 'Authority updates',
-    dataType: 'MARC',
-  },
+  jobProfileName: 'Authority updates',
+  jobProfileId: '448ae575-daec-49c1-8041-d64c8ed8e5b1',
   sourcePath: 'import7.marc',
   fileName: 'import7.marc',
   runBy: {

--- a/lib/tests/jobsLogs.js
+++ b/lib/tests/jobsLogs.js
@@ -2,10 +2,8 @@ const jobsLogsData = [
   {
     id: '67dfac11-1caf-4470-9ad1-d533f6360bdd',
     hrId: 2,
-    jobProfileInfo: {
-      id: '22fafcc3-f582-493d-88b0-3c538480cd83',
-      name: 'Multilingual support check',
-    },
+    jobProfileName: 'Multilingual support check',
+    jobProfileId: '22fafcc3-f582-493d-88b0-3c538480cd83',
     sourcePath: 'path',
     fileName: 'import_28.mrc',
     progress: {
@@ -25,10 +23,8 @@ const jobsLogsData = [
   {
     id: '2e149aef-bb77-45aa-8a28-e139674b55e1',
     hrId: 3,
-    jobProfileInfo: {
-      id: '32fafcc3-f582-493d-88b0-3c538480cd83',
-      name: 'Standard BIB profile',
-    },
+    jobProfileName: 'Standard BIB profile',
+    jobProfileId: '32fafcc3-f582-493d-88b0-3c538480cd83',
     sourcePath: 'path',
     fileName: 'import_22.mrc',
     progress: {
@@ -48,10 +44,8 @@ const jobsLogsData = [
   {
     id: '4aa3f7f9-3fe5-4a29-a149-72f7b08879da',
     hrId: 1,
-    jobProfileInfo: {
-      id: '44fafcc3-f582-493d-88b0-3c538480cd83',
-      name: 'BIB profile with customized Holdings',
-    },
+    jobProfileName: 'BIB profile with customized Holdings',
+    jobProfileId: '44fafcc3-f582-493d-88b0-3c538480cd83',
     sourcePath: 'path',
     fileName: 'import_22.mrc',
     progress: {
@@ -71,10 +65,8 @@ const jobsLogsData = [
   {
     id: '2e149aef-bb77-45aa-8a28-e139674b55e1',
     hrId: 4,
-    jobProfileInfo: {
-      id: '32fafcc3-f582-493d-88b0-3c538480cd83',
-      name: 'Standard BIB profile',
-    },
+    jobProfileName: 'Standard BIB profile',
+    jobProfileId: '32fafcc3-f582-493d-88b0-3c538480cd83',
     sourcePath: 'path',
     fileName: 'import_21.mrc',
     progress: {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-router-dom": "^5.0.1",
-    "react-intl": "~4.6.10",
+    "react-intl": "^4.7.2",
     "regenerator-runtime": "^0.13.3",
     "core-js": "^3.6.1",
     "sinon": "^7.1.1"
@@ -53,7 +53,7 @@
     "@folio/stripes": "^4.0.0",
     "pretender": "*",
     "react": "*",
-    "react-intl": "~4.6.10",
+    "react-intl": "^4.7.2",
     "react-router": "*",
     "react-router-dom": "*"
   },


### PR DESCRIPTION
## Purposes

Add job names display from backend response instead of "default" value. [Story](https://issues.folio.org/browse/UIDEXP-116)

**Additional change:** unpin react-intl version according to broken change fixing in 4.7.2

**Screenshots:**
![Screen Shot 2020-06-25 at 12 52 56 PM](https://user-images.githubusercontent.com/50317804/85697941-e5a6cf00-b6e2-11ea-8db7-b770c49e4f3c.png)
