### PR TITLE
UIDEXP-86: Extend `SettingsLabel` with ability to provide arbitrary label content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for stripes-data-transfer-components
 
-## 2.1.0 (IN PROGRESS)
+## 2.0.1 (IN PROGRESS)
 * Fix error screen display in case of missed user information in job executions. UIDEXP-107.
 * Update properties in ProfilesPopoverInteractor and export ProfilesLabelInteractors. UIDEXP-53.
 * Add job name display in job logs and executions. UIDEXP-116.
+* Extend `SettingsLabel` with ability to provide arbitrary label content. UIDEXP-86.
 
 ## [2.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.1...v2.0.0)

--- a/lib/Settings/SettingsLabel/SettingsLabel.js
+++ b/lib/Settings/SettingsLabel/SettingsLabel.js
@@ -8,6 +8,7 @@ const SettingsLabel = ({
   messageId,
   iconKey,
   app,
+  children,
 }) => {
   return (
     <div data-test-settings-label>
@@ -16,15 +17,17 @@ const SettingsLabel = ({
         app={app}
         iconKey={iconKey}
       >
-        <FormattedMessage id={messageId} />
+        {messageId && <FormattedMessage id={messageId} />}
+        {children}
       </AppIcon>
     </div>
   );
 };
 
 SettingsLabel.propTypes = {
-  messageId: PropTypes.string.isRequired,
   iconKey: PropTypes.string.isRequired,
+  messageId: PropTypes.string,
+  children: PropTypes.element,
   app: PropTypes.string,
 };
 

--- a/lib/Settings/SettingsLabel/tests/SettingsLabel-test.js
+++ b/lib/Settings/SettingsLabel/tests/SettingsLabel-test.js
@@ -13,7 +13,7 @@ import SettingsLabel from '../SettingsLabel';
 describe('SettingsLabel', () => {
   const settingsLabel = new SettingsLabelInteractor();
 
-  describe('rendering SettingsLabel', () => {
+  describe('rendering SettingsLabel with translation id', () => {
     const messageId = 'test_message_id';
 
     beforeEach(async () => {
@@ -35,6 +35,24 @@ describe('SettingsLabel', () => {
 
     it('should display correct label text', () => {
       expect(settingsLabel.labelText).to.equal(messageId);
+    });
+  });
+
+  describe('rendering SettingsLabel with arbitrary label content', () => {
+    const content = 'label text';
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <SettingsLabel iconKey="mappingProfiles">{content}</SettingsLabel>
+      );
+    });
+
+    it('should display settings label', () => {
+      expect(settingsLabel.isPresent).to.be.true;
+    });
+
+    it('should display correct label text', () => {
+      expect(settingsLabel.labelText).to.equal(content);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-router-dom": "*"
   },
   "stripes": {
-    "type": "",
+    "actAs": [""],
     "icons": [
       {
         "name": "mappingProfiles",


### PR DESCRIPTION
## Purpose

Extend `SettingsLabel` with ability to provide arbitrary label content in the scope of the [UIDEXP-86](https://issues.folio.org/browse/UIDEXP-86).