### PR TITLE
UIDEXP-86: Provide a correct `actsAs` key to the stripes config

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-router-dom": "*"
   },
   "stripes": {
-    "actAs": [""],
+    "actsAs": [""],
     "icons": [
       {
         "name": "mappingProfiles",


### PR DESCRIPTION
## Purpose

Provide a correct `actsAs` key to the stripes config in the scope of the [UIDEXP-86](https://issues.folio.org/browse/UIDEXP-86).