### PR TITLE
Try to fix stale version envs

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-router-dom": "*"
   },
   "stripes": {
-    "actsAs": [""],
+    "type": "",
     "icons": [
       {
         "name": "mappingProfiles",


### PR DESCRIPTION
## Purpose

I have a hunch that because of usage of `actsAs` instead of `type` in stripes config for some reason environments now retrieve the stale version of the package which now breaks stuff. Let's see if returning to the previous approach will help.