### PR TITLE
UIDEXP-84: Extend `FullScreenView` to accept `actionMenu` prop

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,23 +83,6 @@
         "maxBOF": 0
       }
     ],
-    "react/prop-types": [
-      "error",
-      {
-        "skipUndeclared": true
-      }
-    ],
-    "react/jsx-one-expression-per-line": "off",
-    "react/jsx-wrap-multilines": [
-      "error"
-    ],
-    "react/jsx-max-props-per-line": [
-      "error",
-      {
-        "maximum": 1,
-        "when": "always"
-      }
-    ],
     "no-void": "off",
     "comma-dangle": [
       "error",
@@ -119,6 +102,7 @@
       "error",
       "as-needed"
     ],
+    "no-use-before-define": "off",
     "prefer-template": "error",
     "no-else-return": "error",
     "newline-per-chained-call": "error",
@@ -126,8 +110,34 @@
       "error",
       "unix"
     ],
-    "react/jsx-no-useless-fragment": "error",
-    "no-use-before-define": "off",
-    "prefer-object-spread": "off"
+    "prefer-object-spread": "off",
+    "react/prop-types": [
+      "error",
+      {
+        "skipUndeclared": true
+      }
+    ],
+    "react/jsx-one-expression-per-line": "off",
+    "react/jsx-wrap-multilines": [
+      "error"
+    ],
+    "react/jsx-max-props-per-line": [
+      "error",
+      {
+        "maximum": 1,
+        "when": "always"
+      }
+    ],
+    "react/jsx-sort-props": [
+      1,
+      {
+        "noSortAlphabetically": true,
+        "ignoreCase": true,
+        "callbacksLast": true,
+        "shorthandLast": false,
+        "reservedFirst": false
+      }
+    ],
+    "react/jsx-no-useless-fragment": "error"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Update properties in ProfilesPopoverInteractor and export ProfilesLabelInteractors. UIDEXP-53.
 * Add job name display in job logs and executions. UIDEXP-116.
 * Extend `SettingsLabel` with ability to provide arbitrary label content. UIDEXP-86.
-* Extend `FullScreenView` to accept `actionMenu` prop. UIDEXP-84.
+* Extend `FullScreenView` to accept `actionMenu` prop. Sync up eslint config with data-export and replace deprecated `type` with `actAs` in package.json. UIDEXP-84.
 
 ## [2.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.1...v2.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update properties in ProfilesPopoverInteractor and export ProfilesLabelInteractors. UIDEXP-53.
 * Add job name display in job logs and executions. UIDEXP-116.
 * Extend `SettingsLabel` with ability to provide arbitrary label content. UIDEXP-86.
+* Extend `FullScreenView` to accept `actionMenu` prop. UIDEXP-84.
 
 ## [2.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0) (2020-06-12)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v1.0.1...v2.0.0)

--- a/lib/FullScreenForm/tests/FullScreenForm-test.js
+++ b/lib/FullScreenForm/tests/FullScreenForm-test.js
@@ -30,9 +30,9 @@ async function setupFullScreenForm({
       paneTitle={paneTitle}
       submitButtonText={submitButtonText}
       cancelButtonText={cancelButtonText}
-      onCancel={handleCancel}
       isSubmitButtonDisabled={isSubmitButtonDisabled}
       contentClassName={contentClassName}
+      onCancel={handleCancel}
       onSubmit={e => {
         e.preventDefault();
 

--- a/lib/FullScreenView/FullScreenView.js
+++ b/lib/FullScreenView/FullScreenView.js
@@ -9,7 +9,6 @@ import {
   Pane,
   PaneMenu,
   IconButton,
-  Button,
 } from '@folio/stripes/components';
 
 import css from './FullScreenView.css';
@@ -18,6 +17,7 @@ export const FullScreenView = ({
   id = 'full-screen-view',
   children,
   paneTitle,
+  actionMenu,
   onCancel,
 }) => {
   const headerCloseButtonRef = useRef();
@@ -49,12 +49,7 @@ export const FullScreenView = ({
         defaultWidth="100%"
         paneTitle={paneTitle}
         firstMenu={firstMenu}
-        actionMenu={({ onToggle }) => (
-          <Button
-            buttonStyle="dropdownItem fullWidth"
-            onClick={onToggle}
-          />
-        )}
+        actionMenu={actionMenu}
       >
         <div
           data-test-full-screen-view-content
@@ -72,4 +67,5 @@ FullScreenView.propTypes = {
   onCancel: PropTypes.func.isRequired,
   paneTitle: PropTypes.node.isRequired,
   children: PropTypes.node,
+  actionMenu: PropTypes.node,
 };

--- a/lib/FullScreenView/tests/FullScreenView-test.js
+++ b/lib/FullScreenView/tests/FullScreenView-test.js
@@ -21,6 +21,7 @@ async function setupFullScreenView({
     <FullScreenView
       data-test-full-screen-view
       paneTitle={paneTitle}
+      actionMenu={() => <button type="button">Some action</button>}
       onCancel={handleCancel}
     >
       {children}

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -238,10 +238,10 @@ export class SearchAndSortPane extends Component {
         columnWidths={columnWidths}
         formatter={resultsFormatter}
         resultCountIncrement={resultCountIncrement}
-        onHeaderClick={this.handleSort}
         sortOrder={sortOrder}
         sortDirection={sortDirection}
         rowProps={{ to: id => `${match.path}/view/${id}${location.search}` }}
+        onHeaderClick={this.handleSort}
         {...searchResultsProps}
       />
     );

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-router-dom": "*"
   },
   "stripes": {
-    "type": "",
+    "actsAs": [""],
     "icons": [
       {
         "name": "mappingProfiles",

--- a/translations/stripes-data-transfer-components/en.json
+++ b/translations/stripes-data-transfer-components/en.json
@@ -28,5 +28,8 @@
   "recordTypes.marc-hold": "MARC Holdings",
   "search": "Search",
   "validation.enterValue": "Please enter a value",
-  "new": "New"
+  "new": "New",
+  "edit": "Edit",
+  "duplicate": "Duplicate",
+  "delete": "Delete"
 }


### PR DESCRIPTION
## Purpose

* Extend `FullScreenView` to accept `actionMenu` prop
* Sync up eslint config with data-export
* Replace deprecated `type` with `actAs` in package.json

in the scope of the [UIDEXP-84](https://issues.folio.org/browse/UIDEXP-84).