### PR TITLE
STDTC-3: Update export and imports to make them consistent using named approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0 (IN PROGRESS)
 * Update list formatters and list properties generators to fix rows accessibility. UIDEXP-117.
+* Update export and imports to make them consistent using named approach. STDTC-3.
 
 ## [2.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0...v2.0.1)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export { default as EndOfItem } from './lib/EndOfItem';
+export * from './lib/EndOfItem';
 export {
   JobsList,
   Job,
@@ -6,8 +6,8 @@ export {
   sortRunningJobs,
   JobsListAccordion,
 } from './lib/Jobs';
-export { Progress } from './lib/Progress';
-export { default as Preloader } from './lib/Preloader';
+export * from './lib/Progress';
+export * from './lib/Preloader';
 export {
   sortCollection,
   createUrl,

--- a/interactors.js
+++ b/interactors.js
@@ -3,8 +3,8 @@ export * from './lib/SearchAndSortPane/tests/SearchAndSortInteractor';
 export * from './lib/FullScreenForm/tests/interactor';
 export * from './lib/FullScreenView/tests/interactor';
 export * from './lib/Settings/ProfilesLabel/tests/interactors';
-export { default as PreloaderInteractor } from './lib/Preloader/tests/interactor';
-export { default as ProgressInteractor } from './lib/Progress/tests/interactor';
+export * from './lib/Preloader/tests/interactor';
+export * from './lib/Progress/tests/interactor';
 
 export {
   mount,

--- a/lib/EndOfItem/EndOfItem.js
+++ b/lib/EndOfItem/EndOfItem.js
@@ -8,7 +8,7 @@ import {
   Icon,
 } from '@folio/stripes/components';
 
-const EndOfItem = memo(({
+export const EndOfItem = memo(({
   title = <FormattedMessage id="stripes-components.endOfList" />,
   className,
 }) => (
@@ -21,5 +21,3 @@ EndOfItem.propTypes = {
   title: PropTypes.node,
   className: PropTypes.string,
 };
-
-export default EndOfItem;

--- a/lib/EndOfItem/index.js
+++ b/lib/EndOfItem/index.js
@@ -1,1 +1,1 @@
-export { default } from './EndOfItem';
+export * from './EndOfItem';

--- a/lib/EndOfItem/tests/EndOfItem-test.js
+++ b/lib/EndOfItem/tests/EndOfItem-test.js
@@ -10,8 +10,8 @@ import {
   mount,
   mountWithContext,
 } from '../../../test/bigtest/helpers';
-import EndOfItemInteractor from './interactor';
-import EndOfItem from '../EndOfItem';
+import { EndOfItemInteractor } from './interactor';
+import { EndOfItem } from '../EndOfItem';
 
 describe('EndOfItem', () => {
   const endOfItem = new EndOfItemInteractor();

--- a/lib/EndOfItem/tests/interactor.js
+++ b/lib/EndOfItem/tests/interactor.js
@@ -6,8 +6,8 @@ import {
 } from '@bigtest/interactor';
 
 import { hasClassBeginningWith } from '../../../test/bigtest/helpers';
-
-export default @interactor class EnfOfItemInteractor {
+@interactor
+export class EndOfItemInteractor {
   isLayoutContainerPresent = isPresent('[data-test-layout]');
   isLayoutCentered = hasClassBeginningWith('[data-test-layout]', 'textCentered--');
   label = new Interactor('span[class*=label--]');

--- a/lib/JobLogs/JobLogs.js
+++ b/lib/JobLogs/JobLogs.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 
 import { MultiColumnList } from '@folio/stripes/components';
 
-import Preloader from '../Preloader';
+import { Preloader } from '../Preloader';
 import { withJobLogsSort } from './withJobLogsSort';
 import { jobExecutionPropTypes } from '../Jobs';
 
-const JobLogs = props => {
+const JobLogsComponent = props => {
   const {
     formatter,
     contentData,
@@ -39,7 +39,7 @@ const JobLogs = props => {
   );
 };
 
-JobLogs.propTypes = {
+JobLogsComponent.propTypes = {
   formatter: PropTypes.object.isRequired,
   sortField: PropTypes.string.isRequired,
   sortDirection: PropTypes.string.isRequired,
@@ -52,9 +52,9 @@ JobLogs.propTypes = {
   visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-JobLogs.defaultProps = {
+JobLogsComponent.defaultProps = {
   contentData: [],
   hasLoaded: false,
 };
 
-export default withJobLogsSort(JobLogs);
+export const JobLogs = withJobLogsSort(JobLogsComponent);

--- a/lib/JobLogs/index.js
+++ b/lib/JobLogs/index.js
@@ -1,3 +1,3 @@
 export * from './useJobLogsListFormatter';
 export * from './columnProperties';
-export { default as JobLogs } from './JobLogs';
+export * from './JobLogs';

--- a/lib/JobLogs/tests/jobLogs-test.js
+++ b/lib/JobLogs/tests/jobLogs-test.js
@@ -11,14 +11,14 @@ import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumn
 
 import translation from '../../../translations/stripes-data-transfer-components/en';
 import { mountWithContext } from '../../../test/bigtest/helpers';
-import PreloaderInteractor from '../../Preloader/tests/interactor';
+import { PreloaderInteractor } from '../../Preloader/tests/interactor';
 import { useJobLogsListFormatter } from '../useJobLogsListFormatter';
 import {
   DEFAULT_JOB_LOGS_COLUMNS,
   useJobLogsProperties,
 } from '../columnProperties';
 import { jobsLogs } from '../../tests/jobsLogs';
-import JobLogs from '../JobLogs';
+import { JobLogs } from '../JobLogs';
 
 const containerSize = {
   height: '1000px',

--- a/lib/JobLogs/tests/useJobLogsListFormatter-test.js
+++ b/lib/JobLogs/tests/useJobLogsListFormatter-test.js
@@ -4,7 +4,7 @@ import {
   it,
 } from '@bigtest/mocha';
 
-import jobExecution from '../../tests/jobExecution';
+import { jobExecution } from '../../tests/jobExecution';
 import { useJobLogsListFormatter } from '../useJobLogsListFormatter';
 import { getHookExecutionResult } from '../../../test/bigtest/helpers';
 

--- a/lib/Jobs/Job/Job.js
+++ b/lib/Jobs/Job/Job.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import css from './Job.css';
 
-const Job = props => {
+export const Job = props => {
   const { children } = props;
 
   return (
@@ -14,5 +14,3 @@ const Job = props => {
     </li>
   );
 };
-
-export default Job;

--- a/lib/Jobs/Job/index.js
+++ b/lib/Jobs/Job/index.js
@@ -1,1 +1,1 @@
-export { default } from './Job';
+export * from './Job';

--- a/lib/Jobs/Job/tests/Job-test.js
+++ b/lib/Jobs/Job/tests/Job-test.js
@@ -7,8 +7,8 @@ import {
 import { expect } from 'chai';
 
 import { mount } from '../../../../test/bigtest/helpers';
-import Job from '../Job';
-import JobInteractor from './interactor';
+import { Job } from '../Job';
+import { JobInteractor } from './interactor';
 
 describe('Job', () => {
   const job = new JobInteractor();

--- a/lib/Jobs/Job/tests/interactor.js
+++ b/lib/Jobs/Job/tests/interactor.js
@@ -1,5 +1,6 @@
 import { interactor } from '@bigtest/interactor';
 
-export default interactor(class JobInteractor {
+@interactor
+export class JobInteractor {
   static defaultScope = '[data-test-job-item]';
-});
+}

--- a/lib/Jobs/JobsList/JobsList.js
+++ b/lib/Jobs/JobsList/JobsList.js
@@ -6,13 +6,13 @@ import {
   Layout,
 } from '@folio/stripes/components';
 
-import EndOfItem from '../../EndOfItem';
-import Preloader from '../../Preloader';
-import jobExecutionPropTypes from '../jobExecutionPropTypes';
+import { EndOfItem } from '../../EndOfItem';
+import { Preloader } from '../../Preloader';
+import { jobExecutionPropTypes } from '../jobExecutionPropTypes';
 
 import css from './JobsList.css';
 
-const JobsList = ({
+export const JobsList = ({
   jobs,
   hasLoaded,
   itemFormatter,
@@ -57,5 +57,3 @@ JobsList.propTypes = {
   hasLoaded: PropTypes.bool.isRequired,
   isEmptyMessage: PropTypes.node,
 };
-
-export default JobsList;

--- a/lib/Jobs/JobsList/index.js
+++ b/lib/Jobs/JobsList/index.js
@@ -1,1 +1,1 @@
-export { default } from './JobsList';
+export * from './JobsList';

--- a/lib/Jobs/JobsList/tests/JobsList-test.js
+++ b/lib/Jobs/JobsList/tests/JobsList-test.js
@@ -7,13 +7,13 @@ import {
 import { expect } from 'chai';
 
 import { mountWithContext } from '../../../../test/bigtest/helpers';
-import JobsList from '../JobsList';
-import ItemFormatter from '../../tests/item-formatter';
-import JobsListContainerInteractor from './interactor';
-import PreloaderInteractor from '../../../Preloader/tests/interactor';
-import EndOfItemInteractor from '../../../EndOfItem/tests/interactor';
-import JobInteractor from '../../Job/tests/interactor';
-import jobExecution from '../../../tests/jobExecution';
+import { JobsList } from '../JobsList';
+import { ItemFormatter } from '../../tests/item-formatter';
+import { JobsListContainerInteractor } from './interactor';
+import { PreloaderInteractor } from '../../../Preloader/tests/interactor';
+import { EndOfItemInteractor } from '../../../EndOfItem/tests/interactor';
+import { JobInteractor } from '../../Job/tests/interactor';
+import { jobExecution } from '../../../tests/jobExecution';
 
 describe('JobList', () => {
   const jobListContainer = new JobsListContainerInteractor();

--- a/lib/Jobs/JobsList/tests/interactor.js
+++ b/lib/Jobs/JobsList/tests/interactor.js
@@ -4,10 +4,11 @@ import {
   count,
 } from '@bigtest/interactor';
 
-export default interactor(class JobListContainerInteractor {
+@interactor
+export class JobsListContainerInteractor {
   static defaultScope = '[data-test-jobs-list-container]';
 
   emptyMessage = new Interactor('[data-test-empty-message]');
   list = new Interactor('[data-test-jobs-list]');
   jobsAmount = count('[data-test-job-item]');
-});
+}

--- a/lib/Jobs/JobsListAccordion/JobsListAccordion.js
+++ b/lib/Jobs/JobsListAccordion/JobsListAccordion.js
@@ -8,8 +8,8 @@ import {
   Badge,
 } from '@folio/stripes/components';
 
-import jobExecutionPropTypes from '../jobExecutionPropTypes';
-import JobsList from '../JobsList';
+import { jobExecutionPropTypes } from '../jobExecutionPropTypes';
+import { JobsList } from '../JobsList';
 
 const getClosedDisplay = (hasLoaded, jobsAmount) => {
   if (hasLoaded) return (<Badge>{jobsAmount}</Badge>);
@@ -22,7 +22,7 @@ const getClosedDisplay = (hasLoaded, jobsAmount) => {
   );
 };
 
-const JobsListAccordion = props => {
+export const JobsListAccordion = props => {
   const {
     jobs,
     hasLoaded,
@@ -60,5 +60,3 @@ JobsListAccordion.propTypes = {
   emptyMessageId: PropTypes.string.isRequired,
   jobs: PropTypes.arrayOf(jobExecutionPropTypes).isRequired,
 };
-
-export default JobsListAccordion;

--- a/lib/Jobs/JobsListAccordion/index.js
+++ b/lib/Jobs/JobsListAccordion/index.js
@@ -1,1 +1,1 @@
-export { default } from './JobsListAccordion';
+export * from './JobsListAccordion';

--- a/lib/Jobs/JobsListAccordion/tests/JobsListAccordion-test.js
+++ b/lib/Jobs/JobsListAccordion/tests/JobsListAccordion-test.js
@@ -7,15 +7,15 @@ import {
 import { expect } from 'chai';
 
 import { mountWithContext } from '../../../../test/bigtest/helpers';
-import JobsListAccordion from '../JobsListAccordion';
-import JobsListAccordionInteractor from './interactor';
-import jobExecution from '../../../tests/jobExecution';
-import ItemFormatter from '../../tests/item-formatter';
-import JobsListInteractor from '../../JobsList/tests/interactor';
+import { JobsListAccordion } from '../JobsListAccordion';
+import { JobsListAccordionInteractor } from './interactor';
+import { jobExecution } from '../../../tests/jobExecution';
+import { ItemFormatter } from '../../tests/item-formatter';
+import { JobsListContainerInteractor } from '../../JobsList/tests/interactor';
 
 describe('JobsListAccordion', () => {
   const accordion = new JobsListAccordionInteractor();
-  const jobsList = new JobsListInteractor();
+  const jobsList = new JobsListContainerInteractor();
 
   const titleId = 'accordion title';
   const emptyMessageId = 'noRunningJobsMessage';

--- a/lib/Jobs/JobsListAccordion/tests/interactor.js
+++ b/lib/Jobs/JobsListAccordion/tests/interactor.js
@@ -6,7 +6,7 @@ import {
 } from '@bigtest/interactor';
 
 @interactor
-export default class JobsAccordionInteractor {
+export class JobsListAccordionInteractor {
   static defaultScope = '[data-test-accordion-section]';
 
   title = text('[data-test-jobs-accordion-title]');

--- a/lib/Jobs/RunningJobs/index.js
+++ b/lib/Jobs/RunningJobs/index.js
@@ -1,1 +1,1 @@
-export { default } from './sortRunningJobs';
+export * from './sortRunningJobs';

--- a/lib/Jobs/RunningJobs/sortRunningJobs.js
+++ b/lib/Jobs/RunningJobs/sortRunningJobs.js
@@ -11,8 +11,6 @@ const sortByDates = (
   return convertDate(startedDateB, DATE_TYPES.number) - convertDate(startedDateA, DATE_TYPES.number);
 };
 
-const sortRunningJobs = jobs => {
+export const sortRunningJobs = jobs => {
   return sortCollection(jobs, [sortByDates]);
 };
-
-export default sortRunningJobs;

--- a/lib/Jobs/RunningJobs/tests/sortRunningJobs-test.js
+++ b/lib/Jobs/RunningJobs/tests/sortRunningJobs-test.js
@@ -4,7 +4,7 @@ import {
   it,
 } from '@bigtest/mocha';
 
-import sortRunningJobs from '../sortRunningJobs';
+import { sortRunningJobs } from '../sortRunningJobs';
 
 const runningJobsUnsorted = [
   { startedDate: '2018-10-19T18:33:45.000' },

--- a/lib/Jobs/index.js
+++ b/lib/Jobs/index.js
@@ -1,5 +1,5 @@
-export { default as JobsList } from './JobsList';
-export { default as Job } from './Job';
-export { default as jobExecutionPropTypes } from './jobExecutionPropTypes';
-export { default as sortRunningJobs } from './RunningJobs';
-export { default as JobsListAccordion } from './JobsListAccordion';
+export * from './JobsList';
+export * from './Job';
+export * from './jobExecutionPropTypes';
+export * from './RunningJobs';
+export * from './JobsListAccordion';

--- a/lib/Jobs/jobExecutionPropTypes.js
+++ b/lib/Jobs/jobExecutionPropTypes.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-const jobExecutionPropTypes = PropTypes.shape({
+export const jobExecutionPropTypes = PropTypes.shape({
   id: PropTypes.string.isRequired,
   hrId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   jobProfileName: PropTypes.string,
@@ -19,5 +19,3 @@ const jobExecutionPropTypes = PropTypes.shape({
   uiStatus: PropTypes.string,
   userId: PropTypes.string,
 });
-
-export default jobExecutionPropTypes;

--- a/lib/Jobs/tests/item-formatter.js
+++ b/lib/Jobs/tests/item-formatter.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import Job from '../Job';
+import { Job } from '../Job';
 
-const ItemFormatter = job => (
+export const ItemFormatter = job => (
   <Job
     key={job.hrId}
     job={job}
@@ -10,5 +10,3 @@ const ItemFormatter = job => (
     Job details
   </Job>
 );
-
-export default ItemFormatter;

--- a/lib/Preloader/Preloader.js
+++ b/lib/Preloader/Preloader.js
@@ -5,7 +5,7 @@ import {
   Layout,
 } from '@folio/stripes/components';
 
-const Preloader = memo(({ message }) => (
+export const Preloader = memo(({ message }) => (
   <Layout
     className="flex centerContent"
     data-test-preloader
@@ -14,5 +14,3 @@ const Preloader = memo(({ message }) => (
     <Loading size="large" />
   </Layout>
 ));
-
-export default Preloader;

--- a/lib/Preloader/index.js
+++ b/lib/Preloader/index.js
@@ -1,1 +1,1 @@
-export { default } from './Preloader';
+export * from './Preloader';

--- a/lib/Preloader/tests/Preloader-test.js
+++ b/lib/Preloader/tests/Preloader-test.js
@@ -7,8 +7,8 @@ import {
 import { expect } from 'chai';
 
 import { mount } from '../../../test/bigtest/helpers';
-import Preloader from '../Preloader';
-import PreloaderInteractor from './interactor';
+import { Preloader } from '../Preloader';
+import { PreloaderInteractor } from './interactor';
 
 describe('Preloader', () => {
   const preloader = new PreloaderInteractor();

--- a/lib/Preloader/tests/interactor.js
+++ b/lib/Preloader/tests/interactor.js
@@ -3,8 +3,9 @@ import {
   interactor,
 } from '@bigtest/interactor';
 
-export default interactor(class PreloaderInteractor {
+@interactor
+export class PreloaderInteractor {
   static defaultScope = '[data-test-preloader]';
 
   isSpinnerPresent = isPresent('[class*=spinner---]');
-});
+}

--- a/lib/Progress/Progress.js
+++ b/lib/Progress/Progress.js
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 
 import { calculatePercentage } from '../utils';
-import Preloader from '../Preloader';
+import { Preloader } from '../Preloader';
 
 import css from './Progress.css';
 
@@ -24,7 +24,7 @@ const progressInfoFormatters = {
   },
 };
 
-const Progress = memo(({
+export const Progress = memo(({
   current,
   total,
   progressInfoType = 'percentage',
@@ -63,5 +63,3 @@ Progress.propTypes = {
   progressCurrentClassName: PropTypes.string,
   progressInfoClassName: PropTypes.string,
 };
-
-export default Progress;

--- a/lib/Progress/index.js
+++ b/lib/Progress/index.js
@@ -1,1 +1,1 @@
-export { default as Progress } from './Progress';
+export * from './Progress';

--- a/lib/Progress/tests/Progress-test.js
+++ b/lib/Progress/tests/Progress-test.js
@@ -6,9 +6,9 @@ import {
 } from '@bigtest/mocha';
 import { expect } from 'chai';
 
-import Progress from '../Progress';
-import ProgressInteractor from './interactor';
-import PreloaderInteractor from '../../Preloader/tests/interactor';
+import { Progress } from '../Progress';
+import { ProgressInteractor } from './interactor';
+import { PreloaderInteractor } from '../../Preloader/tests/interactor';
 import { mount } from '../../../test/bigtest/helpers';
 
 describe('Progress', () => {

--- a/lib/Progress/tests/interactor.js
+++ b/lib/Progress/tests/interactor.js
@@ -4,9 +4,10 @@ import {
   text,
 } from '@bigtest/interactor';
 
-export default interactor(class ProgressInteractor {
+@interactor
+export class ProgressInteractor {
   static defaultScope = '[data-test-progress-bar]';
 
   currentProgressStyles = property('[class*=progressCurrent---', 'style');
   progressInfoText = text('[class*=progressInfo---]');
-});
+}

--- a/lib/SearchAndSortPane/tests/DefaultHeaderInteractor.js
+++ b/lib/SearchAndSortPane/tests/DefaultHeaderInteractor.js
@@ -4,7 +4,7 @@ import {
 } from '@bigtest/interactor';
 
 import ButtonInteractor from '@folio/stripes-components/lib/Button/tests/interactor';
-import SettingsLabelInteractor from '../../Settings/SettingsLabel/tests/interactor';
+import { SettingsLabelInteractor } from '../../Settings/SettingsLabel/tests/interactor';
 
 @interactor
 export class DefaultHeaderInteractor {

--- a/lib/SearchResults/SearchResults.js
+++ b/lib/SearchResults/SearchResults.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { MultiColumnList } from '@folio/stripes/components';
 
-import Preloader from '../Preloader';
+import { Preloader } from '../Preloader';
 
 export function SearchResults({
   source,

--- a/lib/SearchResults/tests/interactor.js
+++ b/lib/SearchResults/tests/interactor.js
@@ -5,7 +5,7 @@ import {
 
 import MultiColumnListInteractor from '@folio/stripes-components/lib/MultiColumnList/tests/interactor';
 
-import PreloaderInteractor from '../../Preloader/tests/interactor';
+import { PreloaderInteractor } from '../../Preloader/tests/interactor';
 
 @interactor
 export class SearchResultsInteractor {

--- a/lib/Settings/JobProfiles/JobProfiles.js
+++ b/lib/Settings/JobProfiles/JobProfiles.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { SettingsLabel } from '../SettingsLabel';
 import { SearchAndSortPane } from '../../SearchAndSortPane';
 
-const JobProfiles = props => {
+export const JobProfiles = props => {
   const {
     formatter,
     titleId,
@@ -45,5 +45,3 @@ JobProfiles.defaultProps = {
   initialResultCount: 30,
   resourceName: 'jobProfiles',
 };
-
-export default JobProfiles;

--- a/lib/Settings/JobProfiles/index.js
+++ b/lib/Settings/JobProfiles/index.js
@@ -1,2 +1,2 @@
-export { default as JobProfiles } from './JobProfiles';
+export * from './JobProfiles';
 export * from './columnProperties';

--- a/lib/Settings/JobProfiles/tests/JobProfiles-test.js
+++ b/lib/Settings/JobProfiles/tests/JobProfiles-test.js
@@ -8,16 +8,14 @@ import {
 } from '@bigtest/mocha';
 
 import { mountWithContext } from '../../../../test/bigtest/helpers';
-import JobProfiles from '../JobProfiles';
+import { JobProfiles } from '../JobProfiles';
 import {
   useJobProfilesProperties,
   DEFAULT_JOB_PROFILES_COLUMNS,
 } from '../columnProperties';
-
 import { useListFormatter } from '../../../ListFormatter';
-
 import { SearchAndSortInteractor } from '../../../SearchAndSortPane/tests/SearchAndSortInteractor';
-import jobProfilesData from './jobProfilesData';
+import { jobProfilesData } from './jobProfilesData';
 import translations from '../../../../translations/stripes-data-transfer-components/en';
 import {
   buildMutator,

--- a/lib/Settings/JobProfiles/tests/jobProfilesData.js
+++ b/lib/Settings/JobProfiles/tests/jobProfilesData.js
@@ -1,4 +1,4 @@
-const jobProfilesData = [
+export const jobProfilesData = [
   {
     name: 'A Lorem ipsum 1',
     description: 'Description 1',
@@ -37,5 +37,3 @@ const jobProfilesData = [
     metadata: { updatedDate: '2018-12-07T11:45:21.000+0000' },
   },
 ];
-
-export default jobProfilesData;

--- a/lib/Settings/MappingProfiles/MappingProfiles.js
+++ b/lib/Settings/MappingProfiles/MappingProfiles.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { SettingsLabel } from '../SettingsLabel';
 import { SearchAndSortPane } from '../../SearchAndSortPane';
 
-const MappingProfiles = props => {
+export const MappingProfiles = props => {
   const { formatter } = props;
 
   return (
@@ -40,5 +40,3 @@ MappingProfiles.defaultProps = {
   initialResultCount: 30,
   resourceName: 'mappingProfiles',
 };
-
-export default MappingProfiles;

--- a/lib/Settings/MappingProfiles/index.js
+++ b/lib/Settings/MappingProfiles/index.js
@@ -1,3 +1,3 @@
-export { default as MappingProfiles } from './MappingProfiles';
+export * from './MappingProfiles';
 export * from './useMappingProfileListFormatter';
 export * from './columnProperties';

--- a/lib/Settings/MappingProfiles/tests/MappingProfiles-test.js
+++ b/lib/Settings/MappingProfiles/tests/MappingProfiles-test.js
@@ -8,14 +8,14 @@ import {
 } from '@bigtest/mocha';
 
 import { mountWithContext } from '../../../../test/bigtest/helpers';
-import MappingProfiles from '../MappingProfiles';
+import { MappingProfiles } from '../MappingProfiles';
 import {
   useMappingProfilesProperties,
   DEFAULT_MAPPING_PROFILES_COLUMNS,
 } from '../columnProperties';
 import { useMappingProfileListFormatter } from '../useMappingProfileListFormatter';
 import { SearchAndSortInteractor } from '../../../SearchAndSortPane/tests/SearchAndSortInteractor';
-import mappingProfilesData from './mappingProfilesData';
+import { mappingProfilesData } from './mappingProfilesData';
 import translations from '../../../../translations/stripes-data-transfer-components/en';
 import {
   buildMutator,

--- a/lib/Settings/MappingProfiles/tests/mappingProfilesData.js
+++ b/lib/Settings/MappingProfiles/tests/mappingProfilesData.js
@@ -1,4 +1,4 @@
-const mappingProfilesData = [
+export const mappingProfilesData = [
   {
     id: '1737d899-6fb9-44f4-ba16-9a8b111cd61d',
     name: 'AP holdings-MARC Bib',
@@ -108,5 +108,3 @@ const mappingProfilesData = [
     },
   },
 ];
-
-export default mappingProfilesData;

--- a/lib/Settings/MappingProfiles/tests/useMappingProfileListFormatter-test.js
+++ b/lib/Settings/MappingProfiles/tests/useMappingProfileListFormatter-test.js
@@ -4,7 +4,7 @@ import {
   it,
 } from '@bigtest/mocha';
 
-import mappingProfilesData from './mappingProfilesData';
+import { mappingProfilesData } from './mappingProfilesData';
 import { useMappingProfileListFormatter } from '../useMappingProfileListFormatter';
 import { getHookExecutionResult } from '../../../../test/bigtest/helpers';
 

--- a/lib/Settings/ProfilesLabel/ProfilesLabel.js
+++ b/lib/Settings/ProfilesLabel/ProfilesLabel.js
@@ -6,7 +6,7 @@ import { InfoPopover } from '@folio/stripes/components';
 
 import css from './ProfilesLabel.css';
 
-const ProfilesLabel = ({
+export const ProfilesLabel = ({
   link,
   content,
 }) => {
@@ -33,5 +33,3 @@ ProfilesLabel.propTypes = {
   link: PropTypes.string.isRequired,
   content: PropTypes.node.isRequired,
 };
-
-export default ProfilesLabel;

--- a/lib/Settings/ProfilesLabel/index.js
+++ b/lib/Settings/ProfilesLabel/index.js
@@ -1,1 +1,1 @@
-export { default as ProfilesLabel } from './ProfilesLabel';
+export * from './ProfilesLabel';

--- a/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
+++ b/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
@@ -12,7 +12,7 @@ import {
   ProfilesLabelInteractor,
   ProfilesPopoverInteractor,
 } from './interactors';
-import ProfilesLabel from '../ProfilesLabel';
+import { ProfilesLabel } from '../ProfilesLabel';
 
 import translations from '../../../../translations/stripes-data-transfer-components/en';
 

--- a/lib/Settings/ProfilesLabel/tests/interactors/ProfilesLabelInteractor.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/ProfilesLabelInteractor.js
@@ -3,10 +3,9 @@ import {
   scoped,
 } from '@bigtest/interactor';
 
-@interactor class ProfilesLabelInteractor {
+@interactor
+export class ProfilesLabelInteractor {
   static defaultScope = '[data-test-profile-label]';
 
   infoButton = scoped('button');
 }
-
-export default ProfilesLabelInteractor;

--- a/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
@@ -7,12 +7,11 @@ import {
 
 import css from '../../ProfilesLabel.css';
 
-@interactor class ProfilesPopoverInteractor {
+@interactor
+export class ProfilesPopoverInteractor {
   static defaultScope = '[data-role="popover"]';
 
   content = new Interactor(`.${css.profilesPopoverContent}`);
   linkHref = property('[class*=popoverPop---] a', 'href');
   linkText = text('[class*=popoverPop---] a');
 }
-
-export default ProfilesPopoverInteractor;

--- a/lib/Settings/ProfilesLabel/tests/interactors/index.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/index.js
@@ -1,2 +1,2 @@
-export { default as ProfilesLabelInteractor } from './ProfilesLabelInteractor';
-export { default as ProfilesPopoverInteractor } from './ProfilesPopoverInteractor';
+export * from './ProfilesLabelInteractor';
+export * from './ProfilesPopoverInteractor';

--- a/lib/Settings/SettingsLabel/SettingsLabel.js
+++ b/lib/Settings/SettingsLabel/SettingsLabel.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { AppIcon } from '@folio/stripes/core';
 
-const SettingsLabel = ({
+export const SettingsLabel = ({
   messageId,
   iconKey,
   app,
@@ -32,5 +32,3 @@ SettingsLabel.propTypes = {
 };
 
 SettingsLabel.defaultProps = { app: 'stripes-data-transfer-components' };
-
-export default SettingsLabel;

--- a/lib/Settings/SettingsLabel/index.js
+++ b/lib/Settings/SettingsLabel/index.js
@@ -1,1 +1,1 @@
-export { default as SettingsLabel } from './SettingsLabel';
+export * from './SettingsLabel';

--- a/lib/Settings/SettingsLabel/tests/SettingsLabel-test.js
+++ b/lib/Settings/SettingsLabel/tests/SettingsLabel-test.js
@@ -7,8 +7,8 @@ import {
 import { expect } from 'chai';
 
 import { mountWithContext } from '../../../../test/bigtest/helpers';
-import SettingsLabelInteractor from './interactor';
-import SettingsLabel from '../SettingsLabel';
+import { SettingsLabelInteractor } from './interactor';
+import { SettingsLabel } from '../SettingsLabel';
 
 describe('SettingsLabel', () => {
   const settingsLabel = new SettingsLabelInteractor();

--- a/lib/Settings/SettingsLabel/tests/interactor.js
+++ b/lib/Settings/SettingsLabel/tests/interactor.js
@@ -4,11 +4,10 @@ import {
   text,
 } from '@bigtest/interactor';
 
-@interactor class SettingsLabelInteractor {
+@interactor
+export class SettingsLabelInteractor {
   static defaultScope = '[data-test-settings-label]';
 
   icon = new Interactor('[class*=appIcon--]');
   labelText = text('[class*=label---]');
 }
-
-export default SettingsLabelInteractor;

--- a/lib/tests/jobExecution.js
+++ b/lib/tests/jobExecution.js
@@ -1,4 +1,4 @@
-const jobExecution = {
+export const jobExecution = {
   id: 'e451348f-2273-4b45-b385-0a8b0184b4e1',
   hrId: 112984432,
   subordinationType: 'PARENT_SINGLE',
@@ -20,5 +20,3 @@ const jobExecution = {
   status: 'PROCESSING_FINISHED',
   uiStatus: 'READY_FOR_PREVIEW',
 };
-
-export default jobExecution;

--- a/test/bigtest/connectStripes.js
+++ b/test/bigtest/connectStripes.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { withStripes } from '@folio/stripes-core';
 
-export default function connectStripes(component) {
+export function connectStripes(component) {
   class Connected extends Component {
     static propTypes = { stripes: PropTypes.object };
 

--- a/test/bigtest/helpers/Harness.js
+++ b/test/bigtest/helpers/Harness.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { IntlProvider } from 'react-intl';
 
-import prefixKeys from './prefixKeys';
+import { prefixKeys } from './prefixKeys';
 import translations from '../../../translations/stripes-data-transfer-components/en';
 
-class Harness extends React.Component {
+export class Harness extends React.Component {
   render() {
     const allTranslations = prefixKeys(translations);
 
@@ -35,5 +35,3 @@ Harness.propTypes = {
     })
   ),
 };
-
-export default Harness;

--- a/test/bigtest/helpers/index.js
+++ b/test/bigtest/helpers/index.js
@@ -1,6 +1,6 @@
-export { mount } from './mount';
-export { mountWithContext } from './mountWithContext';
-export { selectorFromClassnameString } from './selectorFromClassnameString';
-export { hasClassBeginningWith } from './hasClassBeginningWith';
+export * from './mount';
+export * from './mountWithContext';
+export * from './selectorFromClassnameString';
+export * from './hasClassBeginningWith';
 export * from './wait';
 export * from './getHookExecutionResult';

--- a/test/bigtest/helpers/mountWithContext.js
+++ b/test/bigtest/helpers/mountWithContext.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Harness from './Harness';
+import { Harness } from './Harness';
 import { getCleanTestingRoot } from './getCleanTestingRoot';
 
 export function mountWithContext(component, translations = []) {

--- a/test/bigtest/helpers/prefixKeys.js
+++ b/test/bigtest/helpers/prefixKeys.js
@@ -1,5 +1,5 @@
 // mimics the StripesTranslationPlugin in @folio/stripes-core
-export default function prefixKeys(obj, prefix = 'stripes-data-transfer-components') {
+export function prefixKeys(obj, prefix = 'stripes-data-transfer-components') {
   const res = {};
 
   for (const key of Object.keys(obj)) {


### PR DESCRIPTION
## Purposes

For now, in the project, there are two approaches to deal with imports and exports: default and named. So the idea is to migrate to the named approach to make them consistent. [Story](https://issues.folio.org/browse/STDTC-3).