### PR TITLE
UIDATIMP-535: Update FullScreenView Component to support renderHeader prop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Update list formatters and list properties generators to fix rows accessibility. UIDEXP-117.
 * Update export and imports to make them consistent using named approach. STDTC-3.
 * Remove `@bigtest/mirage` and mirage config files. STDTC-14.
+* Update `FullScreenView` component to support `renderHeader` prop. UIDATIMP-535.
 
 ## [2.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0...v2.0.1)

--- a/lib/FullScreenForm/tests/FullScreenForm-test.js
+++ b/lib/FullScreenForm/tests/FullScreenForm-test.js
@@ -96,10 +96,6 @@ describe('FullScreenForm', () => {
       expect(fullScreenForm.cancelButton.text).to.equal(cancelButtonText);
     });
 
-    it('should display close button in the focused mode', () => {
-      expect(fullScreenForm.closeButton.isFocused).to.be.true;
-    });
-
     describe('clicking on submit button', () => {
       beforeEach(async () => {
         await fullScreenForm.submitButton.click();

--- a/lib/FullScreenView/FullScreenView.js
+++ b/lib/FullScreenView/FullScreenView.js
@@ -1,7 +1,4 @@
-import React, {
-  useRef,
-  useEffect,
-} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
@@ -9,21 +6,23 @@ import {
   Pane,
   PaneMenu,
   IconButton,
+  PaneHeader,
+  Layer,
 } from '@folio/stripes/components';
 
 import css from './FullScreenView.css';
 
 export const FullScreenView = ({
   id = 'full-screen-view',
-  children,
   paneTitle,
   actionMenu,
+  contentLabel,
+  centerContent = true,
+  children,
   onCancel,
+  renderHeader,
+  ...props
 }) => {
-  const headerCloseButtonRef = useRef();
-
-  useEffect(() => headerCloseButtonRef.current.focus(), []);
-
   const firstMenu = (
     <PaneMenu>
       <FormattedMessage id="stripes-components.cancel">
@@ -32,7 +31,6 @@ export const FullScreenView = ({
             data-test-header-close-button
             ariaLabel={ariaLabel}
             icon="times"
-            ref={headerCloseButtonRef}
             onClick={onCancel}
           />
         )}
@@ -40,32 +38,45 @@ export const FullScreenView = ({
     </PaneMenu>
   );
 
+  const renderDefaultHeader = renderProps => (
+    <PaneHeader
+      {...renderProps}
+      paneTitle={paneTitle}
+      actionMenu={actionMenu}
+      firstMenu={firstMenu}
+    />
+  );
+
   return (
-    <div
-      id={id}
-      data-test-full-screen-view
+    <Layer
+      isOpen
+      contentLabel={contentLabel}
     >
       <Pane
+        data-test-full-screen-view
+        id={id}
         defaultWidth="100%"
-        paneTitle={paneTitle}
-        firstMenu={firstMenu}
-        actionMenu={actionMenu}
+        renderHeader={renderHeader || renderDefaultHeader}
+        {...props}
       >
         <div
           data-test-full-screen-view-content
-          className={css.viewContent}
+          className={centerContent && css.viewContent}
         >
           {children}
         </div>
       </Pane>
-    </div>
+    </Layer>
   );
 };
 
 FullScreenView.propTypes = {
   id: PropTypes.string,
-  onCancel: PropTypes.func.isRequired,
-  paneTitle: PropTypes.node.isRequired,
+  onCancel: PropTypes.func,
+  paneTitle: PropTypes.node,
   children: PropTypes.node,
   actionMenu: PropTypes.node,
+  renderHeader: PropTypes.func,
+  centerContent: PropTypes.bool,
+  contentLabel: PropTypes.string.isRequired,
 };

--- a/lib/FullScreenView/tests/FullScreenView-test.js
+++ b/lib/FullScreenView/tests/FullScreenView-test.js
@@ -8,6 +8,8 @@ import {
   it,
 } from '@bigtest/mocha';
 
+import { Paneset } from '@folio/stripes/components';
+
 import { mountWithContext } from '../../../test/bigtest/helpers';
 import { FullScreenViewInteractor } from './interactor';
 import { FullScreenView } from '../FullScreenView';
@@ -15,28 +17,31 @@ import { FullScreenView } from '../FullScreenView';
 async function setupFullScreenView({
   paneTitle = 'Pane title',
   handleCancel = noop,
+  renderHeader,
   children,
 }, translations) {
   await mountWithContext(
-    <FullScreenView
-      data-test-full-screen-view
-      paneTitle={paneTitle}
-      actionMenu={() => <button type="button">Some action</button>}
-      onCancel={handleCancel}
-    >
-      {children}
-    </FullScreenView>,
+    <Paneset>
+      <FullScreenView
+        paneTitle={paneTitle}
+        actionMenu={() => <button type="button">Some action</button>}
+        renderHeader={renderHeader}
+        onCancel={handleCancel}
+      >
+        {children}
+      </FullScreenView>
+    </Paneset>,
     translations
   );
 }
 
 describe('FullScreenView', () => {
   const fullScreenView = new FullScreenViewInteractor();
+  const paneTitle = 'Pane title';
+  const handleCancel = sinon.spy();
+  const renderHeader = sinon.spy();
 
-  describe('rendering FullScreenView', () => {
-    const paneTitle = 'Pane title';
-    const handleCancel = sinon.spy();
-
+  describe('rendering FullScreenView without renderHeader prop', () => {
     beforeEach(async () => {
       handleCancel.resetHistory();
 
@@ -58,6 +63,10 @@ describe('FullScreenView', () => {
       expect(fullScreenView.$('[data-test-children]')).to.not.be.undefined;
     });
 
+    it('renderHeader should not be called', () => {
+      expect(renderHeader.called).to.be.false;
+    });
+
     describe('clicking on close button', () => {
       beforeEach(async () => {
         await fullScreenView.closeButton.click();
@@ -66,6 +75,21 @@ describe('FullScreenView', () => {
       it('should call the subscribed callback', () => {
         expect(handleCancel.called).to.be.true;
       });
+    });
+  });
+
+  describe('rendering FullScreenView with renderHeader prop', () => {
+    beforeEach(async () => {
+      renderHeader.resetHistory();
+
+      await setupFullScreenView({
+        renderHeader,
+        children: <span data-test-children>Children</span>,
+      });
+    });
+
+    it('renderHeader should be called', () => {
+      expect(renderHeader.called).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Purpose 

Extend FullScreenView Component to support renderHeader prop. (Component will be used in data-import module. refers to ticket https://issues.folio.org/browse/UIDATIMP-535)
- Add support of renderHeader prop to make component more flexible for usage in different cases
- Remove setting focus on cancel button to have the same behaviour as in other places