### PR TITLE
UIDEXP-142: Extend `SortAndSearchPane` to accept `excludedSortColumns` and `shouldSetInitialSortOnMount` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Update `stripes` to `v5.0.0` and `react-router-dom` to `5.2.0`. Enforce named export usage in `eslint`. Remove `actsAs` from stripes config. STDTC-13.
 * Update `FullScreenView` component to support `noValidate` prop. STDTC-16.
 * Add `OverlayView` component and extend JobLogs API. UIDEXP-18.
+* Extend `SortAndSearchPane` to accept `excludedSortColumns` and `shouldSetInitialSortOnMount` prop. UIDEXP-142.
 
 ## [2.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.1) (2020-07-09)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.0...v2.0.1)

--- a/lib/DataFetcher/DataFetcher.js
+++ b/lib/DataFetcher/DataFetcher.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
-import { DEFAULT_FETCHER_UPDATE_INTERVAL } from '../utils/constants';
+import { DEFAULT_FETCHER_UPDATE_INTERVAL } from '../utils';
 
 export class DataFetcher extends Component {
   state = {
@@ -113,10 +113,7 @@ DataFetcher.propTypes = {
   mutator: PropTypes.object.isRequired,
   resources: PropTypes.object.isRequired,
   updateInterval: PropTypes.number,
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node),
-  ]).isRequired,
+  children: PropTypes.node.isRequired,
   resourcesMappingPath: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.array,

--- a/lib/FileUploader/FileUploader.js
+++ b/lib/FileUploader/FileUploader.js
@@ -109,7 +109,6 @@ FileUploader.propTypes = {
     PropTypes.arrayOf(PropTypes.string),
   ]),
   children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
     PropTypes.func,
   ]),

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -68,6 +68,8 @@ export class SearchAndSortPane extends Component {
       PropTypes.object,
     ]),
     visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+    excludedSortColumns: PropTypes.arrayOf(PropTypes.string),
+    shouldSetInitialSortOnMount: PropTypes.bool,
     columnMapping: PropTypes.object.isRequired,
     columnWidths: PropTypes.object.isRequired,
     resultsFormatter: PropTypes.object.isRequired,
@@ -85,6 +87,7 @@ export class SearchAndSortPane extends Component {
     renderHeader: null,
     defaultSort: '',
     hasSearchForm: true,
+    shouldSetInitialSortOnMount: true,
     searchLabelKey: 'stripes-data-transfer-components.search',
     searchResultsProps: {},
   };
@@ -132,7 +135,12 @@ export class SearchAndSortPane extends Component {
     const {
       defaultSort,
       location: { search },
+      shouldSetInitialSortOnMount,
     } = this.props;
+
+    if (!shouldSetInitialSortOnMount) {
+      return;
+    }
 
     const queryParams = queryString.parse(search);
     const sortOrder = queryParams.sort || defaultSort;
@@ -166,7 +174,12 @@ export class SearchAndSortPane extends Component {
     const {
       maxSortKeys,
       defaultSort,
+      excludedSortColumns,
     } = this.props;
+
+    if (excludedSortColumns && excludedSortColumns.includes(meta.name)) {
+      return;
+    }
 
     const sortOrder = buildSortOrder(this.queryParam('sort') || defaultSort, meta.name, defaultSort, maxSortKeys);
 

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -71,14 +71,14 @@ export class SearchAndSortPane extends Component {
     excludedSortColumns: PropTypes.arrayOf(PropTypes.string),
     shouldSetInitialSortOnMount: PropTypes.bool,
     columnMapping: PropTypes.object.isRequired,
-    columnWidths: PropTypes.object.isRequired,
+    columnWidths: PropTypes.object,
     resultsFormatter: PropTypes.object.isRequired,
     defaultSort: PropTypes.string,
     resourceName: PropTypes.string.isRequired,
     resultCountIncrement: PropTypes.number.isRequired,
     initialResultCount: PropTypes.number.isRequired,
     hasSearchForm: PropTypes.bool,
-    lastMenu: PropTypes.element,
+    lastMenu: PropTypes.node,
     searchResultsProps: PropTypes.object,
   };
 

--- a/lib/SearchAndSortPane/tests/SearchAndSortPane-test.js
+++ b/lib/SearchAndSortPane/tests/SearchAndSortPane-test.js
@@ -24,44 +24,48 @@ import {
 
 import translations from '../../../translations/stripes-data-transfer-components/en';
 
-const parentMutator = buildMutator();
-
 describe('SearchAndSortPane', () => {
   const pane = new SearchAndSortInteractor();
-  const parentResources = buildResources({
-    resourceName: 'profiles',
-    records: [
-      {
-        id: 1,
-        name: 'Test name',
-      },
-      {
-        id: 2,
-        name: 'Test name 2',
-      },
-    ],
-  });
-
-  const visibleColumns = [
-    'id',
-    'name',
-  ];
-  const columnWidths = {
-    id: '70px',
-    name: '70px',
-  };
-  const columnMapping = {
-    id: 'id',
-    name: 'Name',
-  };
-  const formatter = {
-    id: record => record.id,
-    name: record => record.name,
-  };
   const resultCountMessage = 'profiles pane';
   const titleMessageId = 'title message';
+  const searchAndSortPaneCommonProps = {
+    visibleColumns: ['id', 'name', 'hrId'],
+    columnMapping: {
+      id: 'id',
+      name: 'Name',
+      hrId: 'hrId',
+    },
+    resultsFormatter: {
+      id: record => record.id,
+      name: record => record.name,
+    },
+    parentResources: buildResources({
+      resourceName: 'profiles',
+      records: [
+        {
+          id: 1,
+          name: 'Test name',
+        },
+        {
+          id: 2,
+          name: 'Test name 2',
+        },
+      ],
+    }),
+    parentMutator: buildMutator(),
+    resourceName: 'profiles',
+    defaultSort: 'name',
+    resultCountMessageId: resultCountMessage,
+    stripes: { logger: { log: noop } },
+    label: (
+      <SettingsLabel
+        messageId={titleMessageId}
+        iconKey="customIcon"
+      />
+    ),
+  };
 
-  describe('rendering jobs with loaded status and 2 items', () => {
+  describe('rendering component with loaded status and 2 items', () => {
     beforeEach(async () => {
       window.history.pushState({}, document.title, '/');
     });
@@ -73,24 +77,7 @@ describe('SearchAndSortPane', () => {
     beforeEach(async () => {
       await mountWithContext(
         <Router>
-          <SearchAndSortPane
-            label={(
-              <SettingsLabel
-                messageId={titleMessageId}
-                iconKey="customIcon"
-              />
-            )}
-            parentResources={parentResources}
-            parentMutator={parentMutator}
-            resultCountMessageId={resultCountMessage}
-            resultsFormatter={formatter}
-            defaultSort="name"
-            columnWidths={columnWidths}
-            visibleColumns={visibleColumns}
-            columnMapping={columnMapping}
-            stripes={{ logger: { log: noop } }}
-            resourceName="profiles"
-          />
+          <SearchAndSortPane {...searchAndSortPaneCommonProps} />
         </Router>
       );
     });
@@ -190,7 +177,7 @@ describe('SearchAndSortPane', () => {
     });
   });
 
-  describe('rendering component on page with query, custom renderHeader method and maxSortKeys = 1', () => {
+  describe('rendering component on page with query, excludedSortColumns and custom renderHeader method and maxSortKeys = 1', () => {
     const searchQueryValue = 'search';
     const renderHeaderSpy = sinon.spy();
 
@@ -200,24 +187,10 @@ describe('SearchAndSortPane', () => {
       await mountWithContext(
         <Router>
           <SearchAndSortPane
-            label={(
-              <SettingsLabel
-                messageId={titleMessageId}
-                iconKey="customIcon"
-              />
-            )}
-            parentResources={parentResources}
-            parentMutator={parentMutator}
-            resultCountMessageId={resultCountMessage}
-            resultsFormatter={formatter}
-            defaultSort="name"
-            columnWidths={columnWidths}
-            visibleColumns={visibleColumns}
-            columnMapping={columnMapping}
-            stripes={{ logger: { log: noop } }}
-            resourceName="profiles"
+            excludedSortColumns={['hrId']}
             renderHeader={renderHeaderSpy}
             maxSortKeys={1}
+            {...searchAndSortPaneCommonProps}
           />
         </Router>
       );
@@ -231,13 +204,37 @@ describe('SearchAndSortPane', () => {
       expect(renderHeaderSpy.called).to.be.true;
     });
 
-    describe('clicking on non default sort field', () => {
+    describe('clicking on non default sort header column', () => {
+      let prevQueryString;
+
       beforeEach(async () => {
+        prevQueryString = window.location.search;
         await pane.searchResults.list.headers(0).click();
       });
 
       it('should change sort query in url to sort by one field', () => {
         expect(window.location.search).to.equal('?query=search&sort=id');
+      });
+
+      it('should change query string', () => {
+        const curQueryString = window.location.search;
+
+        expect(prevQueryString).to.not.equal(curQueryString);
+      });
+    });
+
+    describe('clicking on disallowed to sort header column', () => {
+      let prevQueryString;
+
+      beforeEach(async () => {
+        prevQueryString = window.location.search;
+        await pane.searchResults.list.headers(2).click();
+      });
+
+      it('should not change query string', () => {
+        const curQueryString = window.location.search;
+
+        expect(prevQueryString).to.equal(curQueryString);
       });
     });
   });
@@ -250,28 +247,13 @@ describe('SearchAndSortPane', () => {
       await mountWithContext(
         <Router>
           <SearchAndSortPane
-            label={(
-              <SettingsLabel
-                messageId={titleMessageId}
-                iconKey="customIcon"
-              />
-            )}
-            parentResources={parentResources}
-            parentMutator={parentMutator}
-            resultCountMessageId={resultCountMessage}
-            resultsFormatter={formatter}
-            defaultSort="name"
-            columnWidths={columnWidths}
-            visibleColumns={visibleColumns}
-            columnMapping={columnMapping}
-            stripes={{ logger: { log: noop } }}
-            resourceName="profiles"
             hasSearchForm={false}
             lastMenu={<span data-test-custom-last-menu />}
             searchResultsProps={{
               rowProps: null,
               onRowClick: onRowClickSpy,
             }}
+            {...searchAndSortPaneCommonProps}
           />
         </Router>
       );
@@ -293,6 +275,31 @@ describe('SearchAndSortPane', () => {
       it('should call the subscribed callback provided via props for search results', () => {
         expect(onRowClickSpy.called).to.be.true;
       });
+    });
+  });
+
+  describe('rendering component without setting initial sort on mount', () => {
+    beforeEach(async () => {
+      window.history.pushState({}, document.title, '/');
+    });
+
+    afterEach(async () => {
+      window.history.pushState({}, document.title, '/');
+    });
+
+    beforeEach(async () => {
+      await mountWithContext(
+        <Router>
+          <SearchAndSortPane
+            shouldSetInitialSortOnMount={false}
+            {...searchAndSortPaneCommonProps}
+          />
+        </Router>
+      );
+    });
+
+    it('should have empty query string', () => {
+      expect(window.location.search).to.equal('');
     });
   });
 });


### PR DESCRIPTION
## Purpose

Extend `SortAndSearchPane` to accept `excludedSortColumns` and `shouldSetInitialSortOnMount` prop in the scope of the [UIDEXP-142](https://issues.folio.org/browse/UIDEXP-142).