### PR TITLE
UIDEXP-190: Update scopes related to InfoPopover in interactors to fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.0 (IN PROGRESS)
 * Export test utils in order to reuse them in data-export for writing tests with jest/react-testing-library. UIDEXP-179.
 * Reuse `<JobsListAccordion>` component from `stripes-data-transfer-components` rep (UIDATIMP-574)
+* Updated interactors related to the `<InfoPopover>` implementation to fix tests. UIDEXP-190.
 
 ## [3.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.1...v3.0.0)

--- a/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
+++ b/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
@@ -20,7 +20,7 @@ describe('ProfilesLabel', () => {
   const profilesLabel = new ProfilesLabelInteractor();
   const popover = new ProfilesPopoverInteractor();
 
-  describe.only('rendering ProfileLabel', () => {
+  describe('rendering ProfileLabel', () => {
     const link = 'http://localhost/';
     const content = <div data-profiles-label-content>Content</div>;
 

--- a/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
+++ b/lib/Settings/ProfilesLabel/tests/ProfilesLabel-test.js
@@ -20,7 +20,7 @@ describe('ProfilesLabel', () => {
   const profilesLabel = new ProfilesLabelInteractor();
   const popover = new ProfilesPopoverInteractor();
 
-  describe('rendering ProfileLabel', () => {
+  describe.only('rendering ProfileLabel', () => {
     const link = 'http://localhost/';
     const content = <div data-profiles-label-content>Content</div>;
 
@@ -54,8 +54,7 @@ describe('ProfilesLabel', () => {
       expect(profilesLabel.infoButton.isPresent).to.be.true;
     });
 
-    // TODO handle in scope of the UIDEXP-190
-    describe.skip('clicking on info icon button', () => {
+    describe('clicking on info icon button', () => {
       beforeEach(async () => {
         await profilesLabel.infoButton.click();
         await new Promise(resolve => { setTimeout(() => resolve(), 1000); });

--- a/lib/Settings/ProfilesLabel/tests/interactors/ProfilesLabelInteractor.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/ProfilesLabelInteractor.js
@@ -7,5 +7,5 @@ import {
 export class ProfilesLabelInteractor {
   static defaultScope = '[data-test-profile-label]';
 
-  infoButton = scoped('button');
+  infoButton = scoped('[data-test-info-popover-trigger]');
 }

--- a/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
+++ b/lib/Settings/ProfilesLabel/tests/interactors/ProfilesPopoverInteractor.js
@@ -9,9 +9,7 @@ import css from '../../ProfilesLabel.css';
 
 @interactor
 export class ProfilesPopoverInteractor {
-  static defaultScope = '[data-role="popover"]';
-
-  content = new Interactor(`.${css.profilesPopoverContent}`);
-  linkHref = property('[class*=popoverPop---] a', 'href');
-  linkText = text('[class*=popoverPop---] a');
+  content = new Interactor('[data-test-info-popover-content]');
+  linkHref = property('[data-test-info-popover-button]', 'href');
+  linkText = text('[data-test-info-popover-button]');
 }


### PR DESCRIPTION
## Ticket
https://issues.folio.org/browse/UIDEXP-190

## Changes
The markup for the `<InfoPopover>` in stripes-components was changed slightly recently, making the tests break in this repo because of invalid scopes in some interactors. This PR fixes that.