### PR TITLE
UIDEXP-178: Rollback the Instance reacord type translation

### DIFF
--- a/translations/stripes-data-transfer-components/en.json
+++ b/translations/stripes-data-transfer-components/en.json
@@ -21,7 +21,7 @@
   "recordTypes.invoice": "Invoice",
   "recordTypes.item": "Item",
   "recordTypes.items": "Items",
-  "recordTypes.instance": "Inventory instance (selected fields)",
+  "recordTypes.instance": "Instance",
   "recordTypes.holdings": "Holdings",
   "recordTypes.marc-bib": "MARC Bibliographic",
   "recordTypes.marc-auth": "MARC Authority",


### PR DESCRIPTION
In the scope of [[UIDEXP-178]](https://issues.folio.org/browse/UIDEXP-178)

## Purpose
Rolling back translation to it's previous state, since this translation is used in other places, where it supposed to stay the same.