### PR TITLE
UIDATIMP-582: Extend `<SearchForm>` component with additional props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Extend `<Preloader>` component with additional props. UIDATIMP-580.
 * Setup jest/react-testing-library and cover `EndOfItem` and `Progress` components and util methods with tests. STDTC-18.
 * Get rid of default `notLoadedMessage` value for `SearchResults` component. UIDATIMP-581.
+* Extend `<SearchForm>` component with additional props. UIDATIMP-582.
 
 ## [3.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.1...v3.0.0)

--- a/lib/SearchForm/SearchForm.js
+++ b/lib/SearchForm/SearchForm.js
@@ -21,12 +21,12 @@ export function SearchForm({
   searchLabelKey,
   searchTerm,
   isLoading,
+  fieldName,
+  idKey,
   handleChangeIndex,
   handleChange,
   handleClear,
   handleSubmit,
-  fieldName,
-  idKey,
 }) {
   const intl = useIntl();
 
@@ -54,10 +54,10 @@ export function SearchForm({
                 searchableIndexes={searchableIndexes}
                 selectedIndex={selectedIndex}
                 loading={isLoading}
+                name={fieldName}
                 onChangeIndex={handleChangeIndex}
                 onChange={handleChange}
                 onClear={handleClear}
-                name={fieldName}
               />
             )}
           </FormattedMessage>
@@ -85,22 +85,22 @@ SearchForm.propTypes = {
   isLoading: PropTypes.bool,
   selectedIndex: PropTypes.string,
   searchableIndexes: PropTypes.arrayOf(PropTypes.object),
+  fieldName: PropTypes.string,
+  idKey: PropTypes.string,
   handleChangeIndex: PropTypes.func,
   handleChange: PropTypes.func,
   handleClear: PropTypes.func,
   handleSubmit: PropTypes.func,
-  fieldName: PropTypes.string,
-  idKey: PropTypes.string,
 };
 
 SearchForm.defaultProps = {
   isLoading: false,
   searchableIndexes: null,
   selectedIndex: '',
+  fieldName: '',
+  idKey: '',
   handleChangeIndex: noop,
   handleChange: noop,
   handleSubmit: noop,
   handleClear: null,
-  fieldName: '',
-  idKey: '',
 };

--- a/lib/SearchForm/SearchForm.js
+++ b/lib/SearchForm/SearchForm.js
@@ -25,6 +25,8 @@ export function SearchForm({
   handleChange,
   handleClear,
   handleSubmit,
+  fieldName,
+  idKey,
 }) {
   const intl = useIntl();
 
@@ -38,8 +40,8 @@ export function SearchForm({
           <FormattedMessage id={searchLabelKey}>
             {searchDetailsLabel => (
               <SearchField
-                id="input-search-field"
-                clearSearchId="input-search-field-clear-button"
+                id={idKey ? `input-search-${idKey}-field` : 'input-search-field'}
+                clearSearchId={idKey ? `input-${idKey}-search-field-clear-button` : 'input-search-field-clear-button'}
                 data-test-search-form-field
                 ariaLabel={formatTranslationChunks(
                   intl.formatMessage(
@@ -55,6 +57,7 @@ export function SearchForm({
                 onChangeIndex={handleChangeIndex}
                 onChange={handleChange}
                 onClear={handleClear}
+                name={fieldName}
               />
             )}
           </FormattedMessage>
@@ -86,6 +89,8 @@ SearchForm.propTypes = {
   handleChange: PropTypes.func,
   handleClear: PropTypes.func,
   handleSubmit: PropTypes.func,
+  fieldName: PropTypes.string,
+  idKey: PropTypes.string,
 };
 
 SearchForm.defaultProps = {
@@ -96,4 +101,6 @@ SearchForm.defaultProps = {
   handleChange: noop,
   handleSubmit: noop,
   handleClear: null,
+  fieldName: '',
+  idKey: '',
 };

--- a/lib/SearchForm/tests/SearchForm-test.js
+++ b/lib/SearchForm/tests/SearchForm-test.js
@@ -20,6 +20,7 @@ async function setupSearchForm({
   handleClear,
   handleChange,
   handleSubmit,
+  idKey,
 }) {
   const translations = [
     {
@@ -40,6 +41,7 @@ async function setupSearchForm({
         handleSubmit();
       }}
       handleClear={handleClear}
+      idKey={idKey}
     />,
     translations
   );
@@ -121,6 +123,26 @@ describe('SearchForm', () => {
 
     it('should display search form submit button disabled when search form is in the loading state', () => {
       expect(searchForm.searchSubmitButtonDisabled).to.be.true;
+    });
+  });
+
+  describe('rendering search form without provided id key', () => {
+    beforeEach(async () => {
+      await setupSearchForm({});
+    });
+
+    it('should display the default search field id', () => {
+      expect(searchForm.searchField.id).to.equal('input-search-field');
+    });
+  });
+
+  describe('rendering search form with provided id key', () => {
+    beforeEach(async () => {
+      await setupSearchForm({ idKey: 'custom_id_key' });
+    });
+
+    it('should display search field with a unique id', () => {
+      expect(searchForm.searchField.id).to.equal('input-search-custom_id_key-field');
     });
   });
 });

--- a/lib/SearchForm/tests/SearchForm-test.js
+++ b/lib/SearchForm/tests/SearchForm-test.js
@@ -17,10 +17,10 @@ async function setupSearchForm({
   contextName = 'test',
   searchLabelKey = 'test',
   isLoading = false,
+  idKey,
   handleClear,
   handleChange,
   handleSubmit,
-  idKey,
 }) {
   const translations = [
     {
@@ -35,13 +35,13 @@ async function setupSearchForm({
       contextName={contextName}
       searchLabelKey={searchLabelKey}
       isLoading={isLoading}
+      idKey={idKey}
       handleChange={handleChange}
       handleSubmit={e => {
         e.preventDefault();
         handleSubmit();
       }}
       handleClear={handleClear}
-      idKey={idKey}
     />,
     translations
   );


### PR DESCRIPTION
## Purpose

1. Add `idKey` prop to the component to avoid accessibility problems with duplicated `ids` when there is more than one `<SearchForm>` on the page.
2. Add `fieldName` prop to the component to be able to set the `name` to the search field.

## Ref
[UIDATIMP-582](https://issues.folio.org/browse/UIDATIMP-582)