### PR TITLE
STDTC-21: Handle missing job progress field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Setup jest/react-testing-library and cover `EndOfItem` and `Progress` components and util methods with tests. STDTC-18.
 * Get rid of default `notLoadedMessage` value for `SearchResults` component. UIDATIMP-581.
 * Extend `<SearchForm>` component with additional props. UIDATIMP-582.
+* Handle missing job progress field. STDTC-21.
 
 ## [3.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0) (2020-10-15)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v2.0.1...v3.0.0)

--- a/lib/JobLogs/useJobLogsListFormatter.js
+++ b/lib/JobLogs/useJobLogsListFormatter.js
@@ -19,12 +19,8 @@ const runBy = record => {
 const jobProfileName = record => record.jobProfileName;
 
 const totalRecords = record => {
-  const {
-    progress: {
-      exported,
-      total,
-    },
-  } = record;
+  const exported = record.progress?.exported;
+  const total = record.progress?.total;
 
   return exported ? total : '';
 };


### PR DESCRIPTION
## Purpose
In the sope of [STDTC-21](https://issues.folio.org/browse/STDTC-21).
For some edge cases, the progress field for job log is not provided, which causes UI to break. This PR prevents UI from breaking.