### PR TITLE
UIDEXP-143: Update getHookExecutionResult in order for it to be able to return function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Get rid of default `notLoadedMessage` value for `SearchResults` component. UIDATIMP-581.
 * Extend `<SearchForm>` component with additional props. UIDATIMP-582.
 * Rewrite `DataFetcher` using functional component notation. STDTC-34.
+* Update `getHookExecutionResult` in order for it to be able to return function. UIDEXP-143.
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/test/jest/helpers/getHookExecutionResult.js
+++ b/test/jest/helpers/getHookExecutionResult.js
@@ -1,11 +1,18 @@
 import React from 'react';
+import { isFunction } from 'lodash';
 
 import { renderWithIntl } from './renderWithIntl';
 
 export const getHookExecutionResult = (hook, hookArguments = []) => {
-  const result = {};
+  let result = {};
   const TestComponent = () => {
-    Object.assign(result, hook(...hookArguments));
+    const hookResult = hook(...hookArguments);
+
+    if (isFunction(hookResult)) {
+      result = hookResult;
+    } else {
+      Object.assign(result, hookResult);
+    }
 
     return null;
   };


### PR DESCRIPTION
## Purpose 
In scope of [UIDEXP-143](https://issues.folio.org/browse/UIDEXP-143).

Update `getHookExecutionResult` in order for it to be able to return function.