### PR TITLE
UIDEXP-186: Move pretender to dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Extend `<SearchForm>` component with additional props. UIDATIMP-582.
 * Rewrite `DataFetcher` using functional component notation. STDTC-34.
 * Update `getHookExecutionResult` in order for it to be able to return function. UIDEXP-143.
+* Move pretender to dev dependencies. UIDEXP-186.
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/package.json
+++ b/package.json
@@ -58,12 +58,12 @@
     "lodash": "^4.16.4",
     "prop-types": "^15.6.0",
     "query-string": "^5.0.0",
+    "pretender": "^3.4.3",
     "react-dropzone": "^7.0.1",
     "react-router-prop-types": "^1.0.4"
   },
   "peerDependencies": {
     "@folio/stripes": "^5.0.0",
-    "pretender": "*",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "*",


### PR DESCRIPTION
## Purpose

Move pretender to dev dependencies in the scope of the [UIDEXP-186](https://issues.folio.org/browse/UIDEXP-186).