### PR TITLE
UIDATIMP-775 - Change focus when user clicks on Data import app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Rewrite `DataFetcher` using functional component notation. STDTC-34.
 * Update `getHookExecutionResult` in order for it to be able to return function. UIDEXP-143.
 * Move pretender to dev dependencies. UIDEXP-186.
+* Change focus when user clicks on Data import app. UIDATIMP-775
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/lib/FileUploader/FileUploader.js
+++ b/lib/FileUploader/FileUploader.js
@@ -73,6 +73,7 @@ export const FileUploader = ({
                   marginBottom0
                   buttonStyle="primary"
                   onClick={open}
+                  autoFocus
                 >
                   {uploadButtonText}
                 </Button>

--- a/lib/FileUploader/FileUploader.js
+++ b/lib/FileUploader/FileUploader.js
@@ -72,8 +72,8 @@ export const FileUploader = ({
                   data-test-upload-btn
                   marginBottom0
                   buttonStyle="primary"
-                  onClick={open}
                   autoFocus
+                  onClick={open}
                 >
                   {uploadButtonText}
                 </Button>


### PR DESCRIPTION
should also fix UIDEXP-210 - Change focus when user clicks on Data export app

## Approach
- autoFocus property has been added to upload button

## Refs
[UIDATIMP-775](https://issues.folio.org/browse/UIDATIMP-775)
[UIDEXP-210](https://issues.folio.org/browse/UIDEXP-210)