### PR TITLE
UIDEXP-213: Export `getHookExecutionResult` for Bigtest tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * Rewrite `DataFetcher` using functional component notation. STDTC-34.
 * Update `getHookExecutionResult` in order for it to be able to return function. UIDEXP-143.
 * Move pretender to dev dependencies. UIDEXP-186.
-* Change focus when user clicks on Data import app. UIDATIMP-775
+* Change focus when user clicks on Data import app. UIDATIMP-775.
+* Export `getHookExecutionResult` for BigTest tests. UIDEXP-213.
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/interactors.js
+++ b/interactors.js
@@ -9,6 +9,7 @@ export * from './lib/OverlayView/tests/interactor';
 
 export {
   mountWithContext,
+  getHookExecutionResult,
   wait,
 } from './test/bigtest/helpers';
 export * from './test/helpers/stripesResourcesMocks';

--- a/test/bigtest/helpers/getHookExecutionResult.js
+++ b/test/bigtest/helpers/getHookExecutionResult.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { mountWithContext } from './mountWithContext';
 
-export const getHookExecutionResult = (hook, hookArguments = []) => {
+export const getHookExecutionResult = (hook, hookArguments = [], translations = []) => {
   const result = {};
   const TestComponent = () => {
     Object.assign(result, hook(...hookArguments));
@@ -10,7 +10,7 @@ export const getHookExecutionResult = (hook, hookArguments = []) => {
     return null;
   };
 
-  mountWithContext(<TestComponent />);
+  mountWithContext(<TestComponent />, translations);
 
   return result;
 };


### PR DESCRIPTION
## Purpose

Export `getHookExecutionResult` for BigTest tests in the scope of the [UIDEXP-213](https://issues.folio.org/browse/UIDEXP-213).