### PR TITLE
UIDEXP-213: Adjust `getHookExecutionResult` for jest tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Update `getHookExecutionResult` in order for it to be able to return function. UIDEXP-143.
 * Move pretender to dev dependencies. UIDEXP-186.
 * Change focus when user clicks on Data import app. UIDATIMP-775.
-* Export `getHookExecutionResult` for BigTest tests. UIDEXP-213.
+* Export `getHookExecutionResult` for BigTest tests and adjust it for BigTest and jest to work with translations. UIDEXP-213.
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/test/jest/helpers/getHookExecutionResult.js
+++ b/test/jest/helpers/getHookExecutionResult.js
@@ -3,7 +3,7 @@ import { isFunction } from 'lodash';
 
 import { renderWithIntl } from './renderWithIntl';
 
-export const getHookExecutionResult = (hook, hookArguments = []) => {
+export const getHookExecutionResult = (hook, hookArguments = [], translations = []) => {
   let result = {};
   const TestComponent = () => {
     const hookResult = hook(...hookArguments);
@@ -17,7 +17,7 @@ export const getHookExecutionResult = (hook, hookArguments = []) => {
     return null;
   };
 
-  renderWithIntl(<TestComponent />);
+  renderWithIntl(<TestComponent />, translations);
 
   return result;
 };


### PR DESCRIPTION
## Purpose

Adjust it for BigTest and jest and to work with translations in the scope of the [UIDEXP-213](https://issues.folio.org/browse/UIDEXP-213).