### PR TITLE
UIDATIMP-763: Refactor `onNeedMore` function for `SearchResults` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update `getHookExecutionResult` in order for it to be able to return function. UIDEXP-143.
 * Move pretender to dev dependencies. UIDEXP-186.
 * Change focus when user clicks on Data import app. UIDATIMP-775
+* Refactor `onNeedMore` function for `SearchResults` component. UIDATIMP-763
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -60,6 +60,7 @@ export class SearchAndSortPane extends Component {
     parentMutator: PropTypes.shape({
       query: PropTypes.object,
       resultCount: PropTypes.shape({ replace: PropTypes.func.isRequired }).isRequired,
+      resultOffset: PropTypes.shape({ replace: PropTypes.func.isRequired }),
     }).isRequired,
     parentResources: PropTypes.shape({ query: PropTypes.object }).isRequired,
     maxSortKeys: PropTypes.number,
@@ -237,6 +238,7 @@ export class SearchAndSortPane extends Component {
       location,
       resultCountIncrement,
       searchResultsProps,
+      parentMutator: { resultOffset },
     } = this.props;
 
     const sortOrderQuery = this.queryParam('sort') || defaultSort;
@@ -255,6 +257,7 @@ export class SearchAndSortPane extends Component {
         sortDirection={sortDirection}
         rowProps={{ to: id => `${match.path}/view/${id}${location.search}` }}
         onHeaderClick={this.handleSort}
+        resultOffset={resultOffset}
         {...searchResultsProps}
       />
     );

--- a/lib/SearchResults/SearchResults.js
+++ b/lib/SearchResults/SearchResults.js
@@ -9,8 +9,17 @@ export function SearchResults({
   source,
   notLoadedMessage,
   resultCountIncrement,
+  resultOffset,
   ...rest
 }) {
+  const onNeedMore = (askAmount, index) => {
+    if (resultOffset && index) {
+      source.fetchOffset(index);
+    } else {
+      source.fetchMore(resultCountIncrement);
+    }
+  };
+
   return (
     <MultiColumnList
       id="search-results-list"
@@ -20,7 +29,7 @@ export function SearchResults({
       loading={source.pending()}
       autosize
       virtualize
-      onNeedMoreData={() => source.fetchMore(resultCountIncrement)}
+      onNeedMoreData={onNeedMore}
       {...rest}
     />
   );
@@ -32,10 +41,12 @@ SearchResults.propTypes = {
     pending: PropTypes.func.isRequired,
     totalCount: PropTypes.func.isRequired,
     fetchMore: PropTypes.func.isRequired,
+    fetchOffset: PropTypes.func.isRequired,
   }).isRequired,
   resultCountIncrement: PropTypes.number.isRequired,
   notLoadedMessage: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node,
   ]),
+  resultOffset: PropTypes.shape({ replace: PropTypes.func.isRequired }),
 };


### PR DESCRIPTION
## Purpose
Refactor `onNeedMore` function for `SearchResults` component to be able to fetch data by `offset` param.

## Approach
- Add a condition to `onNeedMore`  function to check whether `resultOffset` prop is provided.

## Ref
[UIDATIMP-763](https://issues.folio.org/browse/UIDATIMP-763)