### PR TITLE
UIDEXP-224: Extend `Harnses` test setup component with react-query and stripes providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Enable Progress with 'none' type. UIF-237.
 * Refactor `onNeedMore` function for `SearchResults` component. UIDATIMP-763.
 * Update `stripes` to `v6.0.0`. STDTC-35.
+* Extend `Harnses` test setup component with `react-query` and `stripes` providers. UIDEXP-224.
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-dom": "^16.5.0",
     "react-intl": "^5.7.0",
     "react-router-dom": "^5.2.0",
+    "react-query": "^3.6.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^7.1.1"
   },

--- a/test/bigtest/helpers/mountWithContext.js
+++ b/test/bigtest/helpers/mountWithContext.js
@@ -4,12 +4,13 @@ import ReactDOM from 'react-dom';
 import { Harness } from '../../helpers';
 import { getCleanTestingRoot } from './getCleanTestingRoot';
 
-export function mountWithContext(component, translations = []) {
+export function mountWithContext(component, translations = [], stripes) {
   return new Promise(resolve => {
     ReactDOM.render(
       <Harness
         translations={translations}
         shouldMockOffsetSize={false}
+        stripes={stripes}
       >
         {component}
       </Harness>,

--- a/test/jest/helpers/renderWithIntl.js
+++ b/test/jest/helpers/renderWithIntl.js
@@ -3,8 +3,11 @@ import { render } from '@testing-library/react';
 
 import { Harness } from '../../helpers';
 
-export const renderWithIntl = (children, translations = []) => render(
-  <Harness translations={translations}>
+export const renderWithIntl = (children, translations = [], stripes) => render(
+  <Harness
+    translations={translations}
+    stripes={stripes}
+  >
     {children}
   </Harness>
 );


### PR DESCRIPTION
## Purpose

Extend `Harnses` test setup component with react-query and stripes providers in the scope of the [UIDEXP-224](https://issues.folio.org/browse/UIDEXP-224).