### PR TITLE
STDTC-35: Update `stripes` to `v6.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Export `getHookExecutionResult` for BigTest tests and adjust it for BigTest and jest to work with translations. UIDEXP-213.
 * Enable Progress with 'none' type. UIF-237.
 * Refactor `onNeedMore` function for `SearchResults` component. UIDATIMP-763.
+* Update `stripes` to `v6.0.0`. STDTC-35.
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^6.0.0",
     "@folio/stripes-cli": "^1.18.0",
-    "@folio/stripes-core": "^6.0.0",
-    "@folio/stripes-smart-components": "^5.0.0",
+    "@folio/stripes-core": "^7.0.0",
+    "@folio/stripes-smart-components": "^6.0.0",
     "@testing-library/dom": "^7.26.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^10.4.7",
@@ -63,7 +63,7 @@
     "react-router-prop-types": "^1.0.4"
   },
   "peerDependencies": {
-    "@folio/stripes": "^5.0.0",
+    "@folio/stripes": "^6.0.0",
     "react": "*",
     "react-intl": "^5.7.0",
     "react-router": "*",


### PR DESCRIPTION
## Purpose
In the scope of [STDTC-35](https://issues.folio.org/browse/STDTC-35).
Bump the stripes dependency to version 6.0.0 so UI can work with the latest changes from the modules there. Task also covers the update of stripes related dependencies which also should be updated after the stripes update.

