### PR TITLE
STDTC-38: Update `stripes-cli` to `v2.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Refactor `onNeedMore` function for `SearchResults` component. UIDATIMP-763.
 * Update `stripes` to `v6.0.0`. STDTC-35.
 * Extend `Harnses` test setup component with `react-query` and `stripes` providers. UIDEXP-224.
+* Update `stripes-cli` to `v2.0.0`. STDTC-38.
 
 ## [3.0.2](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2) (2020-11-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.0...v3.0.2)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "@folio/stripes-core": "^7.0.0",
     "@folio/stripes-smart-components": "^6.0.0",
     "@testing-library/dom": "^7.26.3",


### PR DESCRIPTION
## Purpose

Update `stripes-cli` to `v2.0.0` in the scope of the [STDTC-38](https://issues.folio.org/browse/STDTC-38)