### PR TITLE
UIDATIMP-913: Add `firstMenu` prop to the `SearchAndSortPane` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.1.0 (IN PROGRESS)
 * Add `searchInputRef` prop to the `SearchForm` component. UIDATIMP-898.
+* Add `firstMenu` prop to the `SearchAndSortPane` component. UIDATIMP-913.
 
 ## [4.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v4.0.0) (2021-03-11)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/tree/v3.0.2...v4.0.0)

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -79,6 +79,7 @@ export class SearchAndSortPane extends Component {
     resultCountIncrement: PropTypes.number.isRequired,
     initialResultCount: PropTypes.number.isRequired,
     hasSearchForm: PropTypes.bool,
+    firstMenu: PropTypes.node,
     lastMenu: PropTypes.node,
     searchResultsProps: PropTypes.object,
   };
@@ -270,6 +271,7 @@ export class SearchAndSortPane extends Component {
       renderHeader,
       match,
       location,
+      firstMenu,
       lastMenu,
     } = this.props;
 
@@ -285,6 +287,7 @@ export class SearchAndSortPane extends Component {
             values={{ count: this.getSource().totalCount() }}
           />
         )}
+        firstMenu={firstMenu}
         lastMenu={lastMenu || (
           <Button
             buttonStyle="primary paneHeaderNewButton"

--- a/lib/SearchAndSortPane/tests/SearchAndSortPane-test.js
+++ b/lib/SearchAndSortPane/tests/SearchAndSortPane-test.js
@@ -249,6 +249,7 @@ describe('SearchAndSortPane', () => {
           <SearchAndSortPane
             hasSearchForm={false}
             lastMenu={<span data-test-custom-last-menu />}
+            firstMenu={<span data-test-custom-first-menu />}
             searchResultsProps={{
               rowProps: null,
               onRowClick: onRowClickSpy,
@@ -257,6 +258,10 @@ describe('SearchAndSortPane', () => {
           />
         </Router>
       );
+    });
+
+    it('should display custom first menu', () => {
+      expect(pane.header.$('[data-test-custom-first-menu]')).to.not.be.undefined;
     });
 
     it('should display custom last menu', () => {


### PR DESCRIPTION
### Purpose
Add `firstMenu` prop to the component to be able to render `x` icon so a user can navigate back.

### Ref
https://issues.folio.org/browse/UIDATIMP-913