### PR TITLE
STDTC-52 - Log sort on Data Import landing page not working properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* Log sort on Data Import landing page not working properly. STDTC-52
+
 ## [5.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v5.0.1) (2021-11-04)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v5.0.0...v5.0.1)
 * Fix "Load more" button in SearchAndSortPane. STDTC-48

--- a/lib/utils/sort.js
+++ b/lib/utils/sort.js
@@ -6,7 +6,7 @@
  * @param {string} b
  * @return {number}
  */
-export function sortStrings(a, b) {
+export function sortStrings(a = '', b = '') {
   const valA = a.toUpperCase();
   const valB = b.toUpperCase();
 


### PR DESCRIPTION
## Overview
In Kiwi Bugfest, on the Data Import landing page, clicking on the file name column header to re-sort the column results in an error message.

Records, created through API, has no fileName property, so when we trying to sort by fileName column, it's cause to displayed of error message. 

## Approach
Default value for parameters of sortStrings function were added
