### PR TITLE
STDTC-64: fix accessibility problem for FileUploader and enable mclProps for JobLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * The "Something went wrong" message and the "Return to Data export settings" button are displayed in the "Settings" application page after clicking on the "Mapping profile" item. STDTC-56
 * Compile translations. Refs STDTC-59.
 * When implemented with pagination, <SearchAndSortPane> component doesn't display results for the first page. STDTC-61.
+* Fix accessibility problem of "nested controls" for FileUploader and enable mclProps for JobLogs component. STDTC-64.
 
 ## [5.1.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v5.1.0) (2022-02-03)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v5.0.1...v5.1.0)

--- a/lib/FileUploader/FileUploader.js
+++ b/lib/FileUploader/FileUploader.js
@@ -50,7 +50,7 @@ export const FileUploader = ({
   return (
     <div
       data-test-file-uploader
-      {...getRootProps()}
+      {...getRootProps({ role: 'presentation' })}
       className={updateClassName}
       data-testid="fileUploader-input"
 

--- a/lib/JobLogs/JobLogs.js
+++ b/lib/JobLogs/JobLogs.js
@@ -20,6 +20,7 @@ const JobLogsComponent = props => {
     columnMapping,
     onSort,
     onRowClick,
+    mclProps,
   } = props;
 
   if (!hasLoaded) return <Preloader />;
@@ -38,6 +39,7 @@ const JobLogsComponent = props => {
       autosize
       onRowClick={onRowClick}
       onHeaderClick={onSort}
+      {...mclProps}
     />
   );
 };
@@ -54,6 +56,7 @@ JobLogsComponent.propTypes = {
   visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
   onSort: PropTypes.func.isRequired,
   onRowClick: PropTypes.func,
+  mclProps: PropTypes.object,
 };
 
 JobLogsComponent.defaultProps = {


### PR DESCRIPTION
## Purpose
When enhancing accessibility on folio **Data Import** module, Axe-tools shows two nested controls errors related to STDTC, FileUploader, and JobLogs components, which can be solved by adding a role to FileUploader other than focusable one and for JobLogs by enabling passing props to MCL like **_nonInteractiveHeaders_**

## Approach
Enable passing props to JobLogs.
Add role of  **presentation** to FileUploader container div (input) component.

## REFS
[STDTC](https://issues.folio.org/browse/STDTC-64)
[UIDATIMP-1115](https://issues.folio.org/browse/UIDATIMP-1115)
