### PR TITLE
STDTC-71 suppress react-intl warnings in test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Data Export App - View all logs page - left pane. Refs UIDEXP-64.
 * Fix logic in range filter in ViewAllLogsFilters. Fix STDTC-70.
+* Silence `react-intl` warnings in test harness. Refs STDTC-71.
 
 ## [5.3.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v5.3.0) (2022-10-21)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v5.2.1...v5.3.0)

--- a/test/helpers/Harness.js
+++ b/test/helpers/Harness.js
@@ -61,6 +61,7 @@ export function Harness({
           timeZone="UTC"
           messages={allTranslations}
           defaultRichTextElements={defaultRichTextElements}
+          onWarn={noop}
         >
           {children}
         </IntlProvider>


### PR DESCRIPTION
`react-intl` is really REALLY noisy on the console when it finds uncompiled translations. This is useful in production where we're worried about efficiency, but counter-productive in development where we don't have access to the compiled translations (they're published with releases but not committed to the repository). IOW, the warnings we get about uncompiled translations during development/testing are totally bogus, so this PR silences them.

Refs [STDTC-71](https://issues.folio.org/browse/STDTC-71)