### PR TITLE
STDTC-74: Bump SDTC version to v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Silence `react-intl` warnings in test harness. Refs STDTC-71.
 * Fix logic in range filter in ViewAllLogsFilters. Fix STDTC-70.
 * Move ListTemplate component from ui-data-import to stripes-data-transfer-components. Refs STDTC-69.
+* Bump SDTC version to ^5.4.0. Refs STDTC-74
 
 ## [5.3.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v5.3.0) (2022-10-21)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v5.2.1...v5.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Silence `react-intl` warnings in test harness. Refs STDTC-71.
 * Fix logic in range filter in ViewAllLogsFilters. Fix STDTC-70.
 * Move ListTemplate component from ui-data-import to stripes-data-transfer-components. Refs STDTC-69.
-* Bump SDTC version to ^5.4.0. Refs STDTC-74
+* Bump SDTC version to v5.4.0. Refs STDTC-74
 
 ## [5.3.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v5.3.0) (2022-10-21)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v5.2.1...v5.3.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-data-transfer-components",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Shared components for ui-data-import and ui-data-export projects",
   "main": "src/index.js",
   "repository": "folio-org/stripes-data-transfer-components",


### PR DESCRIPTION
* To use unreleased features, we increased SDTC version from `v5.3.0` to `v5.4.0`
[STDTC-74](https://issues.folio.org/browse/STDTC-74)