### PR TITLE
STDTC-86: Endless "job-profiles" requests when select job profile to run data export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Format numbers in "totalRecords" columns. STDTC-77
 * Fix tests due to changes in react-virtualized-auto-sizer. STDTC-83
 * Add additional props to SearchAndSortPane. Refs STDTC-85.
+* Endless "job-profiles" requests when select job profile to run data export. Refs STDTC-86.
 
 ## [5.4.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v5.4.1) (2023-03-16)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v5.4.0...v5.4.1)

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -96,6 +96,7 @@ export class SearchAndSortPane extends Component {
     shouldSetInitialSortOnMount: true,
     searchLabelKey: 'stripes-data-transfer-components.search',
     searchResultsProps: {},
+    virtualize: true,
   };
 
   constructor(props) {
@@ -367,7 +368,7 @@ export class SearchAndSortPane extends Component {
         paneSub={(
           <FormattedMessage
             id={resultCountMessageId}
-            values={{ count: totalRecordsCount }}
+            values={{ count: totalRecordsCount || this.getSource().totalCount() }}
           />
         )}
         firstMenu={firstMenu}

--- a/lib/SearchResults/SearchResults.js
+++ b/lib/SearchResults/SearchResults.js
@@ -23,10 +23,12 @@ export function SearchResults({
     }
   };
 
+  const totalCount = totalRecordsCount || source.totalCount();
+
   return (
     <MultiColumnList
       id="search-results-list"
-      totalCount={totalRecordsCount}
+      totalCount={totalCount}
       contentData={source.records()}
       pageAmount={pageAmount}
       isEmptyMessage={source.pending() ? <Preloader /> : notLoadedMessage}


### PR DESCRIPTION
Endless "job-profiles" requests when select job profile to run data export
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[STDTC-86](https://issues.folio.org/browse/STDTC-86)
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
