### PR TITLE
STDTC-105: Apply tenant date-time when filter data export logs by date on View all page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add onfilter function to ViewAllLogsFilter. Refs STDTC-99.
 * Fix a crash when viewing Authority DELETE job profile details. Refs STDTC-102.
+* Apply tenant date-time when filter data export logs by date on View all page. Refs STDTC-105.
 
 ## [6.0.1](https://github.com/folio-org/stripes-data-transfer-components/tree/v6.0.1) (2023-12-13)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v6.0.0...v6.0.1)

--- a/lib/ViewAllLogsFilters/ViewAllLogsFilters.js
+++ b/lib/ViewAllLogsFilters/ViewAllLogsFilters.js
@@ -21,7 +21,10 @@ import {
   CheckboxFilter,
   DateRangeFilter,
 } from '@folio/stripes/smart-components';
-import { Pluggable } from '@folio/stripes/core';
+import {
+  Pluggable,
+  useStripes
+} from '@folio/stripes/core';
 
 import {
   FILTERS,
@@ -75,6 +78,7 @@ export const ViewAllLogsFilters = ({
   showUsers,
 }) => {
   const intl = useIntl();
+  const { timezone } = useStripes();
 
   const getJobProfileOptions = uniqBy(jobProfiles.map(jobProfile => ({
     value: jobProfile?.id,
@@ -85,6 +89,14 @@ export const ViewAllLogsFilters = ({
     value: user.userId,
     label: `${user.firstName} ${user.lastName}`,
   })), 'value');
+
+  const onDateRangeChange = (filterData) => {
+    // sets current tenant's timezone
+    moment.tz.setDefault(timezone);
+    onChange(filterData);
+    // restore to a default timezone
+    moment.tz.setDefault();
+  };
 
   return (
     <div data-testid="viewAllLogsFilters">
@@ -117,7 +129,7 @@ export const ViewAllLogsFilters = ({
             selectedValues={getDateRange(activeFilters[FILTERS.STARTED_DATE])}
             makeFilterString={getDateFilter}
             dateFormat={DATE_FORMAT}
-            onChange={onChange}
+            onChange={onDateRangeChange}
           />
         </Accordion>
         <Accordion
@@ -133,7 +145,7 @@ export const ViewAllLogsFilters = ({
             selectedValues={getDateRange(activeFilters[FILTERS.ENDED_DATE])}
             makeFilterString={getDateFilter}
             dateFormat={DATE_FORMAT}
-            onChange={onChange}
+            onChange={onDateRangeChange}
           />
         </Accordion>
         <Accordion

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/stripes-data-transfer-components ./translations/stripes-data-transfer-components/compiled"
   },
   "devDependencies": {
-    "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/eslint-parser": "^7.18.2",
+    "@babel/plugin-transform-runtime": "^7.12.1",
     "@bigtest/interactor": "^0.7.2",
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes": "^9.0.0",
@@ -45,19 +45,20 @@
     "jest-css-modules": "^2.1.0",
     "jest-junit": "^11.0.1",
     "mocha": "^5.2.0",
+    "pretender": "^3.4.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intl": "^6.4.4",
     "react-query": "^3.6.0",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.3",
-    "pretender": "^3.4.3",
     "sinon": "^7.1.1"
   },
   "dependencies": {
     "classnames": "^2.2.5",
     "compose-function": "^3.0.3",
     "lodash": "^4.16.4",
+    "moment": "^2.30.1",
     "prop-types": "^15.6.0",
     "query-string": "^7.1.2",
     "react-dropzone": "^11.3.4",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/STDTC-105
We apply tenant date-time in `Started running`, `Ended running` filters, as it done in` ui-inventory`