### PR TITLE
STDTC-109: Display `Updated by` column in the format `Last name, first name (@user_name)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Add User look-up filter for existing jobs to Logs page. Refs STDTC-97.
+* Display `Updated by` column in the format `Last name, first name (@user_name)`. Fixes STDTC-109.
 
 ## [6.1.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v6.1.0) (2024-03-18)
 [Full Changelog](https://github.com/folio-org/stripes-data-transfer-components/compare/v6.0.1...v6.1.0)

--- a/lib/utils/formatUserName.js
+++ b/lib/utils/formatUserName.js
@@ -18,6 +18,7 @@ export const formatUserName = userInfo => {
   }
 
   const formattedUserName = userName ? `(@${userName})` : userName;
+  const formattedFirstName = firstName ? `, ${firstName}` : firstName;
 
-  return `${firstName} ${lastName} ${formattedUserName}`;
+  return `${lastName}${formattedFirstName} ${formattedUserName}`;
 };

--- a/lib/utils/tests/formatUserName.test.js
+++ b/lib/utils/tests/formatUserName.test.js
@@ -10,10 +10,23 @@ describe('formatUserName function', () => {
       lastName: 'Doe',
       userName: 'admin',
     };
-    const expected = `${userInfo.firstName} ${userInfo.lastName} (@${userInfo.userName})`;
+    const expected = `${userInfo.lastName}, ${userInfo.firstName} (@${userInfo.userName})`;
 
     expect(formatUserName(emptyUserInfo).trim()).toBe('');
     expect(formatUserName(systemUserInfo)).toBe(SYSTEM_USER_NAME);
     expect(formatUserName(userInfo)).toBe(expected);
+  });
+
+  describe('when first name doesn\'t exist', () => {
+    it('should return formatted user name', () => {
+      const userInfo = {
+        firstName: '',
+        lastName: 'Doe',
+        userName: 'admin',
+      };
+      const expected = `${userInfo.lastName} (@${userInfo.userName})`;
+
+      expect(formatUserName(userInfo)).toBe(expected);
+    });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
 * Since the requirements have changed, we need to replace displaying **Updated by** column with the new format **Last name, first name (@user_name)**
 
## Links
[STDTC-109](https://folio-org.atlassian.net/browse/STDTC-109)

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.

## Screenshots

https://github.com/folio-org/stripes-data-transfer-components/assets/85172747/107810dd-d8de-4b40-b016-a4fd7caa62a9


