### PR TITLE
bump workflow's upload-artifact action to v4

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -151,7 +151,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -169,7 +169,7 @@ jobs:
           comment_title: BigTest Unit Test Statistics
 
       - name: Publish BigTest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bigtest-coverage-report
@@ -177,7 +177,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -95,7 +95,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -113,7 +113,7 @@ jobs:
           comment_title: BigTest Unit Test Statistics
 
       - name: Publish BigTest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bigtest-coverage-report
@@ -121,7 +121,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock


### PR DESCRIPTION
GithHub deprecated v2; use v4 instead.
