### PR TITLE
STDTC-122 apply wrappers with flow()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Migrate to shared GA workflows. Refs STDTC-119.
 * *BREAKING* Migrate stripes dependencies to their Sunflower versions. Refs STDTC-120.
 * *BREAKING* Migrate `react-intl` to v7. Refs STDTC-121.
+* Apply wrappers with `flow()` instead of annotations. Refs STDTC-122.
 
 ## [6.2.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v6.2.0) (2024-10-30)
 

--- a/lib/SearchAndSortPane/SearchAndSortPane.js
+++ b/lib/SearchAndSortPane/SearchAndSortPane.js
@@ -7,6 +7,7 @@ import queryString from 'query-string';
 import { withRouter } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
+  flow,
   get,
   noop,
 } from 'lodash';
@@ -39,9 +40,7 @@ import {
 
 import css from './SearchAndSortPane.css';
 
-@withRouter
-@withStripes
-export class SearchAndSortPane extends Component {
+class SearchAndSortPaneComponent extends Component {
   static propTypes = {
     stripes: stripesShape.isRequired,
     label: PropTypes.node.isRequired,
@@ -427,3 +426,8 @@ export class SearchAndSortPane extends Component {
     );
   }
 }
+
+export const SearchAndSortPane = flow([
+  () => withRouter(SearchAndSortPaneComponent),
+  withStripes,
+])();


### PR DESCRIPTION
Replace annotations such as `@withStripes` with a [`_.flow()`](https://lodash.com/docs/4.17.15#flow)-based syntax for better compatibility with esbuild-loader >= 3.1.0.

Refs [STDTC-122](https://folio-org.atlassian.net/browse/STDTC-122)

