### PR TITLE
Migrate @folio/plugin-find-user to Sunflower version (8.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* Migrate @folio/plugin-find-user to Sunflower version (8.0.0).
+
 ## [7.0.0](https://github.com/folio-org/stripes-data-transfer-components/tree/v7.0.0) (2025-03-12)
 
 * Migrate to shared GA workflows. Refs STDTC-119.

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-router-prop-types": "^1.0.4"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^7.0.0"
+    "@folio/plugin-find-user": "^8.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^10.0.0",


### PR DESCRIPTION
Update missed version for @folio/plugin-find-user.  

Initial changes: https://folio-org.atlassian.net/browse/STDTC-120

